### PR TITLE
Fix clang warnings: -Wmissing-prototypes (330 → 2) and mismatched header guards

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -1977,7 +1977,7 @@ int rtw_check_beacon_data(_adapter *padapter, u8 *pbuf,  int len)
 }
 
 #if CONFIG_RTW_MACADDR_ACL
-void rtw_macaddr_acl_init(_adapter *adapter)
+static void rtw_macaddr_acl_init(_adapter *adapter)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
 	struct wlan_acl_pool *acl = &stapriv->acl_list;
@@ -1996,7 +1996,7 @@ void rtw_macaddr_acl_init(_adapter *adapter)
 	_exit_critical_bh(&(acl_node_q->lock), &irqL);
 }
 
-void rtw_macaddr_acl_deinit(_adapter *adapter)
+static void rtw_macaddr_acl_deinit(_adapter *adapter)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
 	struct wlan_acl_pool *acl = &stapriv->acl_list;
@@ -2272,7 +2272,7 @@ int rtw_ap_set_wep_key(_adapter *padapter, u8 *key, u8 keylen, int keyid, u8 set
 	return rtw_ap_set_key(padapter, key, alg, keyid, set_tx);
 }
 
-u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
+static u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
 {
 #define HIQ_XMIT_COUNTS (6)
 	_irqL irqL;

--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -22,6 +22,7 @@
 #include <drv_types.h>
 #include <hal_btcoex.h>
 #include <hal_data.h>
+#include "rtw_btcoex.h"
 
 
 void rtw_btcoex_Initialize(PADAPTER padapter)

--- a/core/rtw_mi.c
+++ b/core/rtw_mi.c
@@ -33,7 +33,7 @@ void rtw_mi_update_union_chan_inf(_adapter *adapter, u8 ch, u8 offset , u8 bw)
 }
 
 /* Find union about ch, bw, ch_offset of all linked/linking interfaces */
-int _rtw_mi_get_ch_setting_union(_adapter *adapter, u8 *ch, u8 *bw, u8 *offset, bool include_self)
+static int _rtw_mi_get_ch_setting_union(_adapter *adapter, u8 *ch, u8 *bw, u8 *offset, bool include_self)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	_adapter *iface;
@@ -111,7 +111,7 @@ inline int rtw_mi_get_ch_setting_union_no_self(_adapter *adapter, u8 *ch, u8 *bw
 }
 
 /* For now, not return union_ch/bw/offset */
-void _rtw_mi_status(_adapter *adapter, struct mi_state *mstate, bool include_self)
+static void _rtw_mi_status(_adapter *adapter, struct mi_state *mstate, bool include_self)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	_adapter *iface;
@@ -667,7 +667,7 @@ void rtw_mi_buddy_xmit_tasklet_schedule(_adapter *padapter)
 }
 #endif
 
-u8 _rtw_mi_busy_traffic_check(_adapter *padapter, void *data)
+static u8 _rtw_mi_busy_traffic_check(_adapter *padapter, void *data)
 {
 	u32 passtime;
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
@@ -1118,7 +1118,7 @@ _adapter *rtw_get_iface_by_hwport(_adapter *padapter, u8 hw_port)
 /*#define CONFIG_SKB_ALLOCATED*/
 #define DBG_SKB_PROCESS
 #ifdef DBG_SKB_PROCESS
-void rtw_dbg_skb_process(_adapter *padapter, union recv_frame *precvframe, union recv_frame *pcloneframe)
+static void rtw_dbg_skb_process(_adapter *padapter, union recv_frame *precvframe, union recv_frame *pcloneframe)
 {
 	_pkt *pkt_copy, *pkt_org;
 

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -1166,7 +1166,7 @@ static void init_channel_list(_adapter *padapter, RT_CHANNEL_INFO *channel_set,
 
 }
 
-bool rtw_regsty_is_excl_chs(struct registry_priv *regsty, u8 ch)
+static bool rtw_regsty_is_excl_chs(struct registry_priv *regsty, u8 ch)
 {
 	int i;
 
@@ -1508,7 +1508,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 }
 
 #ifdef CONFIG_P2P
-u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
+static u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
 {
 	bool response = _TRUE;
 
@@ -3375,7 +3375,7 @@ unsigned int OnAtim(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-unsigned int on_action_spct_ch_switch(_adapter *padapter, struct sta_info *psta, u8 *ies, uint ies_len)
+static unsigned int on_action_spct_ch_switch(_adapter *padapter, struct sta_info *psta, u8 *ies, uint ies_len)
 {
 	unsigned int ret = _FAIL;
 	struct mlme_ext_priv *mlmeext = &padapter->mlmeextpriv;
@@ -4369,7 +4369,7 @@ void issue_p2p_GO_request(_adapter *padapter, u8 *raddr)
 }
 
 
-void issue_p2p_GO_response(_adapter *padapter, u8 *raddr, u8 *frame_body, uint len, u8 result)
+static void issue_p2p_GO_response(_adapter *padapter, u8 *raddr, u8 *frame_body, uint len, u8 result)
 {
 
 	unsigned char category = RTW_WLAN_CATEGORY_PUBLIC;
@@ -4803,7 +4803,7 @@ void issue_p2p_GO_response(_adapter *padapter, u8 *raddr, u8 *frame_body, uint l
 
 }
 
-void issue_p2p_GO_confirm(_adapter *padapter, u8 *raddr, u8 result)
+static void issue_p2p_GO_confirm(_adapter *padapter, u8 *raddr, u8 result)
 {
 
 	unsigned char category = RTW_WLAN_CATEGORY_PUBLIC;
@@ -5715,7 +5715,7 @@ void issue_p2p_provision_request(_adapter *padapter, u8 *pssid, u8 ussidlen, u8 
 }
 
 
-u8 is_matched_in_profilelist(u8 *peermacaddr, struct profile_info *profileinfo)
+static u8 is_matched_in_profilelist(u8 *peermacaddr, struct profile_info *profileinfo)
 {
 	u8 i, match_result = 0;
 
@@ -6063,7 +6063,7 @@ void issue_probersp_p2p(_adapter *padapter, unsigned char *da)
 
 }
 
-int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
+static int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
 {
 	int ret = _FAIL;
 	struct xmit_frame		*pmgntframe;
@@ -6438,7 +6438,7 @@ exit:
 
 #endif /* CONFIG_P2P */
 
-s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
+static s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 {
 	_adapter *adapter = rframe->u.hdr.adapter;
 	struct mlme_ext_priv *mlmeext = &(adapter->mlmeextpriv);
@@ -6463,7 +6463,7 @@ s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_p2p(union recv_frame *precv_frame)
+static unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 {
 	_adapter *padapter = precv_frame->u.hdr.adapter;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -6840,7 +6840,7 @@ exit:
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_vendor(union recv_frame *precv_frame)
+static unsigned int on_action_public_vendor(union recv_frame *precv_frame)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -6861,7 +6861,7 @@ exit:
 	return ret;
 }
 
-unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
+static unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -7247,7 +7247,7 @@ unsigned int DoReserved(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
+static struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
 {
 	struct xmit_frame *pmgntframe;
 	struct xmit_buf *pxmitbuf;
@@ -8148,7 +8148,7 @@ void issue_probersp(_adapter *padapter, unsigned char *da, u8 is_valid_p2p_probe
 
 }
 
-int _issue_probereq(_adapter *padapter, NDIS_802_11_SSID *pssid, u8 *da, u8 ch, bool append_wps, int wait_ack)
+static int _issue_probereq(_adapter *padapter, NDIS_802_11_SSID *pssid, u8 *da, u8 ch, bool append_wps, int wait_ack)
 {
 	int ret = _FAIL;
 	struct xmit_frame		*pmgntframe;
@@ -10287,7 +10287,7 @@ static void issue_action_BSSCoexistPacket(_adapter *padapter)
 }
 
 /* Spatial Multiplexing Powersave (SMPS) action frame */
-int _issue_action_SM_PS(_adapter *padapter ,  unsigned char *raddr , u8 NewMimoPsMode ,  u8 wait_ack)
+static int _issue_action_SM_PS(_adapter *padapter ,  unsigned char *raddr , u8 NewMimoPsMode ,  u8 wait_ack)
 {
 
 	int ret = _FAIL;
@@ -12151,7 +12151,7 @@ void _linked_info_dump(_adapter *padapter)
 
 
 }
-void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
+static void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 {
 	int	i = 0;
 	int ret = _SUCCESS;
@@ -12189,7 +12189,7 @@ void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 	}
 }
 
-u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
+static u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 {
 	u8 ret = _FALSE;
 	int i = 0;
@@ -12236,7 +12236,7 @@ u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 	return ret;
 }
 
-u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
+static u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
 {
 	u8 ret = _TRUE;
 
@@ -13509,7 +13509,7 @@ static bool scan_abort_hdl(_adapter *adapter)
 	return ret;
 }
 
-u8 rtw_scan_sparse(_adapter *adapter, struct rtw_ieee80211_channel *ch, u8 ch_num)
+static u8 rtw_scan_sparse(_adapter *adapter, struct rtw_ieee80211_channel *ch, u8 ch_num)
 {
 	/* interval larger than this is treated as backgroud scan */
 #ifndef RTW_SCAN_SPARSE_BG_INTERVAL_MS
@@ -13922,7 +13922,7 @@ void site_survey(_adapter *padapter, u8 survey_channel, RT_SCAN_TYPE ScanType)
 	return;
 }
 
-void survey_done_set_ch_bw(_adapter *padapter)
+static void survey_done_set_ch_bw(_adapter *padapter)
 {
 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 	u8 cur_channel = 0;
@@ -13994,7 +13994,7 @@ exit:
  * Returns: 0: no ps announcement is doing. 1: ps announcement is doing
  */
 
-u8 sitesurvey_ps_annc(_adapter *padapter, bool ps)
+static u8 sitesurvey_ps_annc(_adapter *padapter, bool ps)
 {
 	u8 ps_anc = 0;
 
@@ -14040,7 +14040,7 @@ u8 sitesurvey_ps_annc(struct dvobj_priv *dvobj, bool ps)
 }
 #endif
 
-void sitesurvey_set_igi(_adapter *adapter)
+static void sitesurvey_set_igi(_adapter *adapter)
 {
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 	struct ss_res *ss = &mlmeext->sitesurvey_res;
@@ -14091,7 +14091,7 @@ void sitesurvey_set_igi(_adapter *adapter)
 		break;
 	}
 }
-void sitesurvey_set_msr(_adapter *adapter, bool enter)
+static void sitesurvey_set_msr(_adapter *adapter, bool enter)
 {
 	u8 network_type;
 	struct mlme_ext_priv *pmlmeext = &adapter->mlmeextpriv;

--- a/core/rtw_odm.c
+++ b/core/rtw_odm.c
@@ -192,7 +192,7 @@ inline u8 rtw_odm_get_force_igi_lb(_adapter *adapter)
 	return hal_data->u1ForcedIgiLb;
 }
 
-void rtw_odm_adaptivity_ver_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_ver_msg(void *sel, _adapter *adapter)
 {
 	RTW_PRINT_SEL(sel, "ADAPTIVITY_VERSION "ADAPTIVITY_VERSION"\n");
 }
@@ -200,7 +200,7 @@ void rtw_odm_adaptivity_ver_msg(void *sel, _adapter *adapter)
 #define RTW_ADAPTIVITY_EN_DISABLE 0
 #define RTW_ADAPTIVITY_EN_ENABLE 1
 
-void rtw_odm_adaptivity_en_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_en_msg(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regsty = &adapter->registrypriv;
 	struct mlme_priv *mlme = &adapter->mlmepriv;
@@ -220,7 +220,7 @@ void rtw_odm_adaptivity_en_msg(void *sel, _adapter *adapter)
 #define RTW_ADAPTIVITY_MODE_NORMAL 0
 #define RTW_ADAPTIVITY_MODE_CARRIER_SENSE 1
 
-void rtw_odm_adaptivity_mode_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_mode_msg(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regsty = &adapter->registrypriv;
 
@@ -237,7 +237,7 @@ void rtw_odm_adaptivity_mode_msg(void *sel, _adapter *adapter)
 #define RTW_ADAPTIVITY_DML_DISABLE 0
 #define RTW_ADAPTIVITY_DML_ENABLE 1
 
-void rtw_odm_adaptivity_dml_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_dml_msg(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regsty = &adapter->registrypriv;
 
@@ -251,7 +251,7 @@ void rtw_odm_adaptivity_dml_msg(void *sel, _adapter *adapter)
 		_RTW_PRINT_SEL(sel, "INVALID\n");
 }
 
-void rtw_odm_adaptivity_dc_backoff_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_dc_backoff_msg(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regsty = &adapter->registrypriv;
 

--- a/core/rtw_p2p.c
+++ b/core/rtw_p2p.c
@@ -23,7 +23,7 @@
 
 #ifdef CONFIG_P2P
 
-int rtw_p2p_is_channel_list_ok(u8 desired_ch, u8 *ch_list, u8 ch_cnt)
+static int rtw_p2p_is_channel_list_ok(u8 desired_ch, u8 *ch_list, u8 ch_cnt)
 {
 	int found = 0, i = 0;
 
@@ -36,7 +36,7 @@ int rtw_p2p_is_channel_list_ok(u8 desired_ch, u8 *ch_list, u8 ch_cnt)
 	return found ;
 }
 
-int is_any_client_associated(_adapter *padapter)
+static int is_any_client_associated(_adapter *padapter)
 {
 	return padapter->stapriv.asoc_list_cnt ? _TRUE : _FALSE;
 }
@@ -2551,7 +2551,7 @@ u8 process_p2p_provdisc_resp(struct wifidirect_info *pwdinfo,  u8 *pframe)
 	return _TRUE;
 }
 
-u8 rtw_p2p_get_peer_ch_list(struct wifidirect_info *pwdinfo, u8 *ch_content, u8 ch_cnt, u8 *peer_ch_list)
+static u8 rtw_p2p_get_peer_ch_list(struct wifidirect_info *pwdinfo, u8 *ch_content, u8 ch_cnt, u8 *peer_ch_list)
 {
 	u8 i = 0, j = 0;
 	u8 temp = 0;
@@ -2573,7 +2573,7 @@ u8 rtw_p2p_get_peer_ch_list(struct wifidirect_info *pwdinfo, u8 *ch_content, u8 
 	return ch_no;
 }
 
-u8 rtw_p2p_check_peer_oper_ch(struct mlme_ext_priv *pmlmeext, u8 ch)
+static u8 rtw_p2p_check_peer_oper_ch(struct mlme_ext_priv *pmlmeext, u8 ch)
 {
 	u8 i = 0;
 
@@ -2585,7 +2585,7 @@ u8 rtw_p2p_check_peer_oper_ch(struct mlme_ext_priv *pmlmeext, u8 ch)
 	return _FAIL;
 }
 
-u8 rtw_p2p_ch_inclusion(struct mlme_ext_priv *pmlmeext, u8 *peer_ch_list, u8 peer_ch_num, u8 *ch_list_inclusioned)
+static u8 rtw_p2p_ch_inclusion(struct mlme_ext_priv *pmlmeext, u8 *peer_ch_list, u8 peer_ch_num, u8 *ch_list_inclusioned)
 {
 	int	i = 0, j = 0, temp = 0;
 	u8 ch_no = 0;
@@ -3080,7 +3080,7 @@ u8 process_p2p_presence_req(struct wifidirect_info *pwdinfo, u8 *pframe, uint le
 	return _TRUE;
 }
 
-void find_phase_handler(_adapter	*padapter)
+static void find_phase_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	struct mlme_priv		*pmlmepriv = &padapter->mlmepriv;
@@ -3104,7 +3104,7 @@ void find_phase_handler(_adapter	*padapter)
 
 void p2p_concurrent_handler(_adapter *padapter);
 
-void restore_p2p_state_handler(_adapter	*padapter)
+static void restore_p2p_state_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	struct mlme_priv		*pmlmepriv = &padapter->mlmepriv;
@@ -3139,7 +3139,7 @@ void restore_p2p_state_handler(_adapter	*padapter)
 	}
 }
 
-void pre_tx_invitereq_handler(_adapter	*padapter)
+static void pre_tx_invitereq_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	u8	val8 = 1;
@@ -3151,7 +3151,7 @@ void pre_tx_invitereq_handler(_adapter	*padapter)
 
 }
 
-void pre_tx_provdisc_handler(_adapter	*padapter)
+static void pre_tx_provdisc_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	u8	val8 = 1;
@@ -3163,7 +3163,7 @@ void pre_tx_provdisc_handler(_adapter	*padapter)
 
 }
 
-void pre_tx_negoreq_handler(_adapter	*padapter)
+static void pre_tx_negoreq_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	u8	val8 = 1;
@@ -3603,7 +3603,7 @@ static void rtw_cfg80211_adjust_p2pie_channel(_adapter *padapter, const u8 *fram
 }
 
 #ifdef CONFIG_WFD
-u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
+static u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
 {
 	_adapter *adapter = xframe->padapter;
 	struct wifidirect_info *wdinfo = &adapter->wdinfo;
@@ -3681,7 +3681,7 @@ u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
 }
 #endif /* CONFIG_WFD */
 
-bool rtw_xframe_del_wfd_ie(struct xmit_frame *xframe)
+static bool rtw_xframe_del_wfd_ie(struct xmit_frame *xframe)
 {
 #define DBG_XFRAME_DEL_WFD_IE 0
 
@@ -3758,7 +3758,7 @@ void rtw_xframe_chk_wfd_ie(struct xmit_frame *xframe)
 #endif
 }
 
-u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
+static u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
 {
 	uint attr_contentlen = 0;
 	u8 *pattr = NULL;
@@ -3811,7 +3811,7 @@ u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
 /*
  * return _TRUE if requester is GO, _FALSE if responder is GO
  */
-bool rtw_p2p_nego_intent_compare(u8 req, u8 resp)
+static bool rtw_p2p_nego_intent_compare(u8 req, u8 resp)
 {
 	if (req >> 1 == resp >> 1)
 		return  req & 0x01 ? _TRUE : _FALSE;

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -179,7 +179,7 @@ int ips_leave(_adapter *padapter)
 	int rtw_hw_resume(_adapter *padapter);
 #endif
 
-bool rtw_pwr_unassociated_idle(_adapter *adapter)
+static bool rtw_pwr_unassociated_idle(_adapter *adapter)
 {
 	u8 i;
 	_adapter *iface;
@@ -396,7 +396,7 @@ exit:
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 void pwr_state_check_handler(RTW_TIMER_HDL_ARGS)
 #else
-void pwr_state_check_handler(struct timer_list *t)
+static void pwr_state_check_handler(struct timer_list *t)
 #endif
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
@@ -595,7 +595,7 @@ void rtw_set_rpwm(PADAPTER padapter, u8 pslv)
 
 }
 
-u8 PS_RDY_CHECK(_adapter *padapter)
+static u8 PS_RDY_CHECK(_adapter *padapter)
 {
 	u32 curr_time, delta_time;
 	struct pwrctrl_priv	*pwrpriv = adapter_to_pwrctl(padapter);

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -2658,7 +2658,7 @@ union recv_frame *recvframe_chk_defrag(PADAPTER padapter, union recv_frame *prec
 
 }
 
-int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
+static int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
 {
 	int	a_len, padding_len;
 	u16	nSubframe_Length;
@@ -3833,7 +3833,7 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe, 
 
 }
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe)
+static int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret = _SUCCESS;
 	struct rx_pkt_attrib *pattrib = &rframe->u.hdr.attrib;
@@ -3880,7 +3880,7 @@ exit:
 	return ret;
 }
 #endif
-int recv_func_prehandle(_adapter *padapter, union recv_frame *rframe)
+static int recv_func_prehandle(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret = _SUCCESS;
 	struct rx_pkt_attrib *pattrib = &rframe->u.hdr.attrib;
@@ -3916,7 +3916,7 @@ exit:
 }
 
 /*#define DBG_RX_BMC_FRAME*/
-int recv_func_posthandle(_adapter *padapter, union recv_frame *prframe)
+static int recv_func_posthandle(_adapter *padapter, union recv_frame *prframe)
 {
 	int ret = _SUCCESS;
 	union recv_frame *orig_prframe = prframe;
@@ -4392,7 +4392,7 @@ static void rx_process_link_qual(_adapter *padapter, union recv_frame *prframe)
 #endif /* CONFIG_NEW_SIGNAL_STAT_PROCESS */
 }
 
-void rx_process_phy_info(_adapter *padapter, union recv_frame *rframe)
+static void rx_process_phy_info(_adapter *padapter, union recv_frame *rframe)
 {
 	/* Check RSSI */
 	rx_process_rssi(padapter, rframe);

--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -984,7 +984,7 @@ int rtw_ch_to_bb_gain_sel(int ch)
 	return sel;
 }
 
-s8 rtw_rf_get_kfree_tx_gain_offset(_adapter *padapter, u8 path, u8 ch)
+static s8 rtw_rf_get_kfree_tx_gain_offset(_adapter *padapter, u8 path, u8 ch)
 {
 	s8 kfree_offset = 0;
 

--- a/core/rtw_sdio.c
+++ b/core/rtw_sdio.c
@@ -20,6 +20,7 @@
 
 #include <drv_types.h>		/* struct dvobj_priv and etc. */
 #include <drv_types_sdio.h>	/* RTW_SDIO_ADDR_CMD52_GEN */
+#include "rtw_sdio.h"
 
 /*
  * Description:

--- a/core/rtw_sreset.c
+++ b/core/rtw_sreset.c
@@ -107,7 +107,7 @@ bool sreset_inprogress(_adapter *padapter)
 #endif
 }
 
-void sreset_restore_security_station(_adapter *padapter)
+static void sreset_restore_security_station(_adapter *padapter)
 {
 	u8 EntryId = 0;
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
@@ -158,7 +158,7 @@ void sreset_restore_security_station(_adapter *padapter)
 		}
 }
 
-void sreset_restore_network_station(_adapter *padapter)
+static void sreset_restore_network_station(_adapter *padapter)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
@@ -231,7 +231,7 @@ void sreset_restore_network_station(_adapter *padapter)
 }
 
 
-void sreset_restore_network_status(_adapter *padapter)
+static void sreset_restore_network_status(_adapter *padapter)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -471,7 +471,7 @@ void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_
 		*r_bmp_vht = bmp_vht;
 }
 
-void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u32 *r_bmp_vht)
+static void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u32 *r_bmp_vht)
 {
 	struct macid_ctl_t *macid_ctl = dvobj_to_macidctl(dvobj);
 	u16 bmp_cck_ofdm = 0;
@@ -2943,7 +2943,7 @@ s32 rtw_free_xmitbuf(struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf)
 	return _SUCCESS;
 }
 
-void rtw_init_xmitframe(struct xmit_frame *pxframe)
+static void rtw_init_xmitframe(struct xmit_frame *pxframe)
 {
 	if (pxframe !=  NULL) { /* default value setting */
 		pxframe->buf_addr = NULL;
@@ -3549,7 +3549,7 @@ void rtw_init_hwxmits(struct hw_xmit *phwxmit, sint entry)
 }
 
 #ifdef CONFIG_BR_EXT
-int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
+static int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
 {
 	struct sk_buff *skb = *pskb;
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;
@@ -4983,7 +4983,7 @@ int rtw_sctx_wait(struct submit_ctx *sctx, const char *msg)
 	return ret;
 }
 
-bool rtw_sctx_chk_waring_status(int status)
+static bool rtw_sctx_chk_waring_status(int status)
 {
 	switch (status) {
 	case RTW_SCTX_DONE_UNKNOWN:

--- a/hal/hal_btcoex.c
+++ b/hal/hal_btcoex.c
@@ -303,7 +303,7 @@ static void halbtcoutsrc_LeaveLps(PBTC_COEXIST pBtCoexist)
 	rtw_btcoex_LPS_Leave(padapter);
 }
 
-void halbtcoutsrc_EnterLps(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_EnterLps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -318,7 +318,7 @@ void halbtcoutsrc_EnterLps(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void halbtcoutsrc_NormalLps(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_NormalLps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -345,7 +345,7 @@ void halbtcoutsrc_NormalLps(PBTC_COEXIST pBtCoexist)
  *  Constraint:
  *	   1. this function will request pwrctrl->lock
  */
-void halbtcoutsrc_LeaveLowPower(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_LeaveLowPower(PBTC_COEXIST pBtCoexist)
 {
 #ifdef CONFIG_LPS_LCLK
 	PADAPTER padapter;
@@ -391,7 +391,7 @@ void halbtcoutsrc_LeaveLowPower(PBTC_COEXIST pBtCoexist)
  *  Constraint:
  *	   1. this function will request pwrctrl->lock
  */
-void halbtcoutsrc_NormalLowPower(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_NormalLowPower(PBTC_COEXIST pBtCoexist)
 {
 #ifdef CONFIG_LPS_LCLK
 	PADAPTER padapter;
@@ -406,7 +406,7 @@ void halbtcoutsrc_NormalLowPower(PBTC_COEXIST pBtCoexist)
 #endif /* CONFIG_LPS_LCLK */
 }
 
-void halbtcoutsrc_DisableLowPower(PBTC_COEXIST pBtCoexist, u8 bLowPwrDisable)
+static void halbtcoutsrc_DisableLowPower(PBTC_COEXIST pBtCoexist, u8 bLowPwrDisable)
 {
 	pBtCoexist->bt_info.bt_disable_low_pwr = bLowPwrDisable;
 	if (bLowPwrDisable)
@@ -415,7 +415,7 @@ void halbtcoutsrc_DisableLowPower(PBTC_COEXIST pBtCoexist, u8 bLowPwrDisable)
 		halbtcoutsrc_NormalLowPower(pBtCoexist);	/* original 32k low power behavior. */
 }
 
-void halbtcoutsrc_AggregationCheck(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_AggregationCheck(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 	BOOLEAN bNeedToAct = _FALSE;
@@ -463,7 +463,7 @@ void halbtcoutsrc_AggregationCheck(PBTC_COEXIST pBtCoexist)
 		rtw_btcoex_rx_ampdu_apply(padapter);
 }
 
-u8 halbtcoutsrc_IsWifiBusy(PADAPTER padapter)
+static u8 halbtcoutsrc_IsWifiBusy(PADAPTER padapter)
 {
 	if (rtw_mi_check_status(padapter, MI_AP_MODE))
 		return _TRUE;
@@ -506,7 +506,7 @@ static u32 _halbtcoutsrc_GetWifiLinkStatus(PADAPTER padapter)
 	return portConnectedStatus;
 }
 
-u32 halbtcoutsrc_GetWifiLinkStatus(PBTC_COEXIST pBtCoexist)
+static u32 halbtcoutsrc_GetWifiLinkStatus(PBTC_COEXIST pBtCoexist)
 {
 	/* ================================= */
 	/* return value: */
@@ -643,7 +643,7 @@ exit:
 	return ret;
 }
 
-u32 halbtcoutsrc_GetBtPatchVer(PBTC_COEXIST pBtCoexist)
+static u32 halbtcoutsrc_GetBtPatchVer(PBTC_COEXIST pBtCoexist)
 {
 	if (pBtCoexist->bt_info.get_bt_fw_ver_cnt <= 5) {
 		if (halbtcoutsrc_IsHwMailboxExist(pBtCoexist) == _TRUE) {
@@ -676,7 +676,7 @@ exit:
 	return pBtCoexist->bt_info.bt_real_fw_ver;
 }
 
-s32 halbtcoutsrc_GetWifiRssi(PADAPTER padapter)
+static s32 halbtcoutsrc_GetWifiRssi(PADAPTER padapter)
 {
 	PHAL_DATA_TYPE pHalData;
 	s32 UndecoratedSmoothedPWDB = 0;
@@ -688,7 +688,7 @@ s32 halbtcoutsrc_GetWifiRssi(PADAPTER padapter)
 	return UndecoratedSmoothedPWDB;
 }
 
-u32 halbtcoutsrc_GetBtCoexSupportedFeature(void *pBtcContext)
+static u32 halbtcoutsrc_GetBtCoexSupportedFeature(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -719,7 +719,7 @@ u32 halbtcoutsrc_GetBtCoexSupportedFeature(void *pBtcContext)
 	return data;
 }
 
-u32 halbtcoutsrc_GetBtCoexSupportedVersion(void *pBtcContext)
+static u32 halbtcoutsrc_GetBtCoexSupportedVersion(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -770,7 +770,7 @@ static u8 halbtcoutsrc_GetWifiScanAPNum(PADAPTER padapter)
 	return scan_AP_num;
 }
 
-u8 halbtcoutsrc_Get(void *pBtcContext, u8 getType, void *pOutBuf)
+static u8 halbtcoutsrc_Get(void *pBtcContext, u8 getType, void *pOutBuf)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1032,7 +1032,7 @@ u8 halbtcoutsrc_Get(void *pBtcContext, u8 getType, void *pOutBuf)
 	return ret;
 }
 
-u8 halbtcoutsrc_Set(void *pBtcContext, u8 setType, void *pInBuf)
+static u8 halbtcoutsrc_Set(void *pBtcContext, u8 setType, void *pInBuf)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1226,7 +1226,7 @@ u8 halbtcoutsrc_Set(void *pBtcContext, u8 setType, void *pInBuf)
 	return ret;
 }
 
-u8 halbtcoutsrc_UnderIps(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_UnderIps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 	struct pwrctrl_priv *pwrpriv;
@@ -1251,18 +1251,18 @@ u8 halbtcoutsrc_UnderIps(PBTC_COEXIST pBtCoexist)
 	return _FALSE;
 }
 
-u8 halbtcoutsrc_UnderLps(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_UnderLps(PBTC_COEXIST pBtCoexist)
 {
 	return GLBtcWiFiInLPS;
 }
 
-u8 halbtcoutsrc_Under32K(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_Under32K(PBTC_COEXIST pBtCoexist)
 {
 	/* todo: the method to check whether wifi is under 32K or not */
 	return _FALSE;
 }
 
-u8 halbtcoutsrc_is_autoload_fail(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_is_autoload_fail(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 	PHAL_DATA_TYPE pHalData;
@@ -1273,7 +1273,7 @@ u8 halbtcoutsrc_is_autoload_fail(PBTC_COEXIST pBtCoexist)
 	return pHalData->bautoload_fail_flag;
 }
 
-u8 halbtcoutsrc_is_fw_ready(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_is_fw_ready(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -1282,7 +1282,7 @@ u8 halbtcoutsrc_is_fw_ready(PBTC_COEXIST pBtCoexist)
 	return padapter->bFWReady;
 }
 
-void halbtcoutsrc_DisplayCoexStatistics(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_DisplayCoexStatistics(PBTC_COEXIST pBtCoexist)
 {
 #if 0
 	PADAPTER padapter = (PADAPTER)pBtCoexist->Adapter;
@@ -1448,7 +1448,7 @@ void halbtcoutsrc_DisplayCoexStatistics(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
 {
 #if 0
 	PADAPTER padapter = (PADAPTER)pBtCoexist->Adapter;
@@ -1476,7 +1476,7 @@ void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
 #endif
 }
 
-void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER	padapter = pBtCoexist->Adapter;
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
@@ -1552,7 +1552,7 @@ void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
 	CL_PRINTF(cliBuf);
 }
 
-void halbtcoutsrc_DisplayDbgMsg(void *pBtcContext, u8 dispType)
+static void halbtcoutsrc_DisplayDbgMsg(void *pBtcContext, u8 dispType)
 {
 	PBTC_COEXIST pBtCoexist;
 
@@ -1576,7 +1576,7 @@ void halbtcoutsrc_DisplayDbgMsg(void *pBtcContext, u8 dispType)
 /* ************************************
  *		IO related function
  * ************************************ */
-u8 halbtcoutsrc_Read1Byte(void *pBtcContext, u32 RegAddr)
+static u8 halbtcoutsrc_Read1Byte(void *pBtcContext, u32 RegAddr)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1588,7 +1588,7 @@ u8 halbtcoutsrc_Read1Byte(void *pBtcContext, u32 RegAddr)
 	return rtw_read8(padapter, RegAddr);
 }
 
-u16 halbtcoutsrc_Read2Byte(void *pBtcContext, u32 RegAddr)
+static u16 halbtcoutsrc_Read2Byte(void *pBtcContext, u32 RegAddr)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1600,7 +1600,7 @@ u16 halbtcoutsrc_Read2Byte(void *pBtcContext, u32 RegAddr)
 	return	rtw_read16(padapter, RegAddr);
 }
 
-u32 halbtcoutsrc_Read4Byte(void *pBtcContext, u32 RegAddr)
+static u32 halbtcoutsrc_Read4Byte(void *pBtcContext, u32 RegAddr)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1612,7 +1612,7 @@ u32 halbtcoutsrc_Read4Byte(void *pBtcContext, u32 RegAddr)
 	return	rtw_read32(padapter, RegAddr);
 }
 
-void halbtcoutsrc_Write1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
+static void halbtcoutsrc_Write1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1624,7 +1624,7 @@ void halbtcoutsrc_Write1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 	rtw_write8(padapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_BitMaskWrite1Byte(void *pBtcContext, u32 regAddr, u8 bitMask, u8 data1b)
+static void halbtcoutsrc_BitMaskWrite1Byte(void *pBtcContext, u32 regAddr, u8 bitMask, u8 data1b)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1652,7 +1652,7 @@ void halbtcoutsrc_BitMaskWrite1Byte(void *pBtcContext, u32 regAddr, u8 bitMask, 
 	rtw_write8(padapter, regAddr, data1b);
 }
 
-void halbtcoutsrc_Write2Byte(void *pBtcContext, u32 RegAddr, u16 Data)
+static void halbtcoutsrc_Write2Byte(void *pBtcContext, u32 RegAddr, u16 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1664,7 +1664,7 @@ void halbtcoutsrc_Write2Byte(void *pBtcContext, u32 RegAddr, u16 Data)
 	rtw_write16(padapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_Write4Byte(void *pBtcContext, u32 RegAddr, u32 Data)
+static void halbtcoutsrc_Write4Byte(void *pBtcContext, u32 RegAddr, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1676,7 +1676,7 @@ void halbtcoutsrc_Write4Byte(void *pBtcContext, u32 RegAddr, u32 Data)
 	rtw_write32(padapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_WriteLocalReg1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
+static void halbtcoutsrc_WriteLocalReg1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 {
 	PBTC_COEXIST		pBtCoexist = (PBTC_COEXIST)pBtcContext;
 	PADAPTER			Adapter = pBtCoexist->Adapter;
@@ -1687,7 +1687,7 @@ void halbtcoutsrc_WriteLocalReg1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 		rtw_write8(Adapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_SetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask, u32 Data)
+static void halbtcoutsrc_SetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1700,7 +1700,7 @@ void halbtcoutsrc_SetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask, u32 Data
 }
 
 
-u32 halbtcoutsrc_GetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask)
+static u32 halbtcoutsrc_GetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1712,7 +1712,7 @@ u32 halbtcoutsrc_GetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask)
 	return PHY_QueryBBReg(padapter, RegAddr, BitMask);
 }
 
-void halbtcoutsrc_SetRfReg(void *pBtcContext, u8 eRFPath, u32 RegAddr, u32 BitMask, u32 Data)
+static void halbtcoutsrc_SetRfReg(void *pBtcContext, u8 eRFPath, u32 RegAddr, u32 BitMask, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1724,7 +1724,7 @@ void halbtcoutsrc_SetRfReg(void *pBtcContext, u8 eRFPath, u32 RegAddr, u32 BitMa
 	PHY_SetRFReg(padapter, eRFPath, RegAddr, BitMask, Data);
 }
 
-u32 halbtcoutsrc_GetRfReg(void *pBtcContext, u8 eRFPath, u32 RegAddr, u32 BitMask)
+static u32 halbtcoutsrc_GetRfReg(void *pBtcContext, u8 eRFPath, u32 RegAddr, u32 BitMask)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1736,7 +1736,7 @@ u32 halbtcoutsrc_GetRfReg(void *pBtcContext, u8 eRFPath, u32 RegAddr, u32 BitMas
 	return PHY_QueryRFReg(padapter, eRFPath, RegAddr, BitMask);
 }
 
-u16 halbtcoutsrc_SetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr, u32 Data)
+static u16 halbtcoutsrc_SetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	u16 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -1772,7 +1772,7 @@ u16 halbtcoutsrc_SetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr, u32 Data)
 	return ret;
 }
 
-u8 halbtcoutsrc_SetBtAntDetection(void *pBtcContext, u8 txTime, u8 btChnl)
+static u8 halbtcoutsrc_SetBtAntDetection(void *pBtcContext, u8 txTime, u8 btChnl)
 {
 	/* Always return _FALSE since we don't implement this yet */
 #if 0
@@ -1791,7 +1791,7 @@ u8 halbtcoutsrc_SetBtAntDetection(void *pBtcContext, u8 txTime, u8 btChnl)
 #endif
 }
 
-BOOLEAN
+static BOOLEAN
 halbtcoutsrc_SetBtTRXMASK(
 	IN 	PVOID			pBtcContext,
 	IN	u1Byte			bt_trx_mask
@@ -1818,7 +1818,7 @@ halbtcoutsrc_SetBtTRXMASK(
 #endif
 }
 
-u16 halbtcoutsrc_GetBtReg_with_status(void *pBtcContext, u8 RegType, u32 RegAddr, u32 *data)
+static u16 halbtcoutsrc_GetBtReg_with_status(void *pBtcContext, u8 RegType, u32 RegAddr, u32 *data)
 {
 	PBTC_COEXIST pBtCoexist;
 	u16 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -1851,14 +1851,14 @@ u16 halbtcoutsrc_GetBtReg_with_status(void *pBtcContext, u8 RegType, u32 RegAddr
 	return ret;
 }
 
-u32 halbtcoutsrc_GetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr)
+static u32 halbtcoutsrc_GetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr)
 {
 	u32 regVal;
 	
 	return (BT_STATUS_BT_OP_SUCCESS == halbtcoutsrc_GetBtReg_with_status(pBtcContext, RegType, RegAddr, &regVal)) ? regVal : 0xffffffff;
 }
 
-void halbtcoutsrc_FillH2cCmd(void *pBtcContext, u8 elementId, u32 cmdLen, u8 *pCmdBuffer)
+static void halbtcoutsrc_FillH2cCmd(void *pBtcContext, u8 elementId, u32 cmdLen, u8 *pCmdBuffer)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1939,7 +1939,7 @@ static COL_H2C_STATUS halbtcoutsrc_check_c2h_ack(PADAPTER Adapter, PCOL_SINGLE_H
 	return c2h_status;
 }
 
-COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
+static COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
 		u8 opcode, u8 opcode_ver, u8 *ph2c_par, u8 h2c_par_len)
 {
 	PADAPTER			Adapter = ((struct btc_coexist *)pBtCoexist)->Adapter;
@@ -1986,7 +1986,7 @@ COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
 	return ret_status;
 }
 
-u8 halbtcoutsrc_GetAntDetValFromBt(void *pBtcContext)
+static u8 halbtcoutsrc_GetAntDetValFromBt(void *pBtcContext)
 {
 	/* Always return 0 since we don't implement this yet */
 #if 0
@@ -2006,7 +2006,7 @@ u8 halbtcoutsrc_GetAntDetValFromBt(void *pBtcContext)
 #endif
 }
 
-u8 halbtcoutsrc_GetBleScanTypeFromBt(void *pBtcContext)
+static u8 halbtcoutsrc_GetBleScanTypeFromBt(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2038,7 +2038,7 @@ u8 halbtcoutsrc_GetBleScanTypeFromBt(void *pBtcContext)
 	return data;
 }
 
-u32 halbtcoutsrc_GetBleScanParaFromBt(void *pBtcContext, u8 scanType)
+static u32 halbtcoutsrc_GetBleScanParaFromBt(void *pBtcContext, u8 scanType)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2070,7 +2070,7 @@ u32 halbtcoutsrc_GetBleScanParaFromBt(void *pBtcContext, u8 scanType)
 	return data;
 }
 
-u8 halbtcoutsrc_GetBtAFHMapFromBt(void *pBtcContext, u8 mapType, u8 *afhMap)
+static u8 halbtcoutsrc_GetBtAFHMapFromBt(void *pBtcContext, u8 mapType, u8 *afhMap)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 	u8 buf[2] = {0};
@@ -2124,7 +2124,7 @@ exit:
 	return (ret == BT_STATUS_BT_OP_SUCCESS) ? _TRUE : _FALSE;
 }
 
-u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
+static u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 	PADAPTER		Adapter = pBtCoexist->Adapter;
@@ -2159,7 +2159,7 @@ u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
 
 }
 
-void halbtcoutsrc_phydm_modify_RA_PCR_threshold(void *pBtcContext, u8 RA_offset_direction, u8 RA_threshold_offset)
+static void halbtcoutsrc_phydm_modify_RA_PCR_threshold(void *pBtcContext, u8 RA_offset_direction, u8 RA_threshold_offset)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 
@@ -2169,7 +2169,7 @@ void halbtcoutsrc_phydm_modify_RA_PCR_threshold(void *pBtcContext, u8 RA_offset_
 #endif
 }
 
-u32 halbtcoutsrc_phydm_query_PHY_counter(void *pBtcContext, u8 info_type)
+static u32 halbtcoutsrc_phydm_query_PHY_counter(void *pBtcContext, u8 info_type)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 
@@ -2299,7 +2299,7 @@ void BT_CoexOffloadC2hCheck(PADAPTER Adapter, u8 *Buffer, u8 Length)
 /* ************************************
  *		Extern functions called by other module
  * ************************************ */
-u8 EXhalbtcoutsrc_BindBtCoexWithAdapter(void *padapter)
+static u8 EXhalbtcoutsrc_BindBtCoexWithAdapter(void *padapter)
 {
 	PBTC_COEXIST		pBtCoexist = &GLBtCoexist;
 	u8	antNum = 1, chipType = 0, singleAntPath = 0;
@@ -2494,7 +2494,7 @@ void EXhalbtcoutsrc_PreLoadFirmware(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void EXhalbtcoutsrc_init_hw_config(PBTC_COEXIST pBtCoexist, u8 bWifiOnly)
+static void EXhalbtcoutsrc_init_hw_config(PBTC_COEXIST pBtCoexist, u8 bWifiOnly)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -2542,7 +2542,7 @@ void EXhalbtcoutsrc_init_hw_config(PBTC_COEXIST pBtCoexist, u8 bWifiOnly)
 	}
 }
 
-void EXhalbtcoutsrc_init_coex_dm(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_init_coex_dm(PBTC_COEXIST pBtCoexist)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -2592,7 +2592,7 @@ void EXhalbtcoutsrc_init_coex_dm(PBTC_COEXIST pBtCoexist)
 	pBtCoexist->initilized = _TRUE;
 }
 
-void EXhalbtcoutsrc_ips_notify(PBTC_COEXIST pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_ips_notify(PBTC_COEXIST pBtCoexist, u8 type)
 {
 	u8	ipsType;
 
@@ -2657,7 +2657,7 @@ void EXhalbtcoutsrc_ips_notify(PBTC_COEXIST pBtCoexist, u8 type)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_lps_notify(PBTC_COEXIST pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_lps_notify(PBTC_COEXIST pBtCoexist, u8 type)
 {
 	u8 lpsType;
 
@@ -2718,7 +2718,7 @@ void EXhalbtcoutsrc_lps_notify(PBTC_COEXIST pBtCoexist, u8 type)
 	}
 }
 
-void EXhalbtcoutsrc_scan_notify(PBTC_COEXIST pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_scan_notify(PBTC_COEXIST pBtCoexist, u8 type)
 {
 	u8	scanType;
 
@@ -2812,7 +2812,7 @@ void EXhalbtcoutsrc_SetAntennaPathNotify(PBTC_COEXIST pBtCoexist, u8 type)
 #endif
 }
 
-void EXhalbtcoutsrc_connect_notify(PBTC_COEXIST pBtCoexist, u8 action)
+static void EXhalbtcoutsrc_connect_notify(PBTC_COEXIST pBtCoexist, u8 action)
 {
 	u8	assoType;
 
@@ -2873,7 +2873,7 @@ void EXhalbtcoutsrc_connect_notify(PBTC_COEXIST pBtCoexist, u8 action)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_media_status_notify(PBTC_COEXIST pBtCoexist, RT_MEDIA_STATUS mediaStatus)
+static void EXhalbtcoutsrc_media_status_notify(PBTC_COEXIST pBtCoexist, RT_MEDIA_STATUS mediaStatus)
 {
 	u8 mStatus;
 
@@ -2935,7 +2935,7 @@ void EXhalbtcoutsrc_media_status_notify(PBTC_COEXIST pBtCoexist, RT_MEDIA_STATUS
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_specific_packet_notify(PBTC_COEXIST pBtCoexist, u8 pktType)
+static void EXhalbtcoutsrc_specific_packet_notify(PBTC_COEXIST pBtCoexist, u8 pktType)
 {
 	u8	packetType;
 
@@ -3002,7 +3002,7 @@ void EXhalbtcoutsrc_specific_packet_notify(PBTC_COEXIST pBtCoexist, u8 pktType)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_bt_info_notify(PBTC_COEXIST pBtCoexist, u8 *tmpBuf, u8 length)
+static void EXhalbtcoutsrc_bt_info_notify(PBTC_COEXIST pBtCoexist, u8 *tmpBuf, u8 length)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3114,7 +3114,7 @@ void EXhalbtcoutsrc_StackOperationNotify(PBTC_COEXIST pBtCoexist, u8 type)
 #endif
 }
 
-void EXhalbtcoutsrc_halt_notify(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_halt_notify(PBTC_COEXIST pBtCoexist)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3160,7 +3160,7 @@ void EXhalbtcoutsrc_halt_notify(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void EXhalbtcoutsrc_SwitchBtTRxMask(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_SwitchBtTRxMask(PBTC_COEXIST pBtCoexist)
 {
 	if (IS_HARDWARE_TYPE_8723B(pBtCoexist->Adapter)) {
 		if (pBtCoexist->board_info.btdm_ant_num == 2) {
@@ -3171,7 +3171,7 @@ void EXhalbtcoutsrc_SwitchBtTRxMask(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void EXhalbtcoutsrc_pnp_notify(PBTC_COEXIST pBtCoexist, u8 pnpState)
+static void EXhalbtcoutsrc_pnp_notify(PBTC_COEXIST pBtCoexist, u8 pnpState)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3249,7 +3249,7 @@ void EXhalbtcoutsrc_CoexDmSwitch(PBTC_COEXIST pBtCoexist)
 	halbtcoutsrc_NormalLowPower(pBtCoexist);
 }
 
-void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3304,7 +3304,7 @@ void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_dbg_control(PBTC_COEXIST pBtCoexist, u8 opCode, u8 opLen, u8 *pData)
+static void EXhalbtcoutsrc_dbg_control(PBTC_COEXIST pBtCoexist, u8 opCode, u8 opLen, u8 *pData)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3574,7 +3574,7 @@ void EXhalbtcoutsrc_DisplayAntDetection(PBTC_COEXIST pBtCoexist)
 	halbtcoutsrc_NormalLowPower(pBtCoexist);
 }
 
-void EXhalbtcoutsrc_BTOffOnNotify(PBTC_COEXIST pBtCoexist, u8 bBTON)
+static void EXhalbtcoutsrc_BTOffOnNotify(PBTC_COEXIST pBtCoexist, u8 bBTON)
 {
 #if 0	/*  Jenyu Need commit to windows' SVN */
 	if (IS_HARDWARE_TYPE_8812(pBtCoexist->Adapter)) {
@@ -3584,12 +3584,12 @@ void EXhalbtcoutsrc_BTOffOnNotify(PBTC_COEXIST pBtCoexist, u8 bBTON)
 #endif
 }
 
-void EXhalbtcoutsrc_set_rfe_type(u8 type)
+static void EXhalbtcoutsrc_set_rfe_type(u8 type)
 {
 	GLBtCoexist.board_info.rfe_type= type;
 }
 
-void EXhalbtcoutsrc_switchband_notify(struct btc_coexist *pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_switchband_notify(struct btc_coexist *pBtCoexist, u8 type)
 {
 	if(!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -2607,7 +2607,7 @@ void rtw_hal_set_bssid(_adapter *adapter, u8 *val)
 	RTW_INFO("%s "ADPT_FMT"- hw port -%d BSSID: "MAC_FMT"\n", __func__, ADPT_ARG(adapter), adapter->hw_port, MAC_ARG(val));
 }
 
-void rtw_hal_get_msr(_adapter *adapter, u8 *net_type)
+static void rtw_hal_get_msr(_adapter *adapter, u8 *net_type)
 {
 	switch (adapter->hw_port) {
 	case HW_PORT0:
@@ -2691,7 +2691,7 @@ void rtw_hal_set_msr(_adapter *adapter, u8 net_type)
 	}
 }
 
-void rtw_hal_port_reconfig(_adapter *adapter, u8 port)
+static void rtw_hal_port_reconfig(_adapter *adapter, u8 port)
 {
 #ifdef CONFIG_CONCURRENT_MODE
 	u8 hal_port_num = 0;
@@ -3043,7 +3043,7 @@ inline s32 rtw_hal_set_FwMediaStatusRpt_range_cmd(_adapter *adapter, bool opmode
 	return rtw_hal_set_FwMediaStatusRpt_cmd(adapter, opmode, miracast, miracast_sink, role, macid, 1, macid_end);
 }
 
-void rtw_hal_set_FwRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
+static void rtw_hal_set_FwRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
 {
 	struct	hal_ops *pHalFunc = &padapter->HalFunc;
 	u8	u1H2CRsvdPageParm[H2C_RSVDPAGE_LOC_LEN] = {0};
@@ -3139,7 +3139,7 @@ void rtw_hal_set_output_gpio(_adapter *padapter, u8 index, u8 outputval)
 }
 #endif
 
-void rtw_hal_set_FwAoacRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
+static void rtw_hal_set_FwAoacRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
 {
 	struct	hal_ops *pHalFunc = &padapter->HalFunc;
 	struct	pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
@@ -5944,7 +5944,7 @@ void rtw_hal_construct_NullFunctionData(
 	*pLength = pktlen;
 }
 
-void rtw_hal_construct_ProbeRsp(_adapter *padapter, u8 *pframe, u32 *pLength,
+static void rtw_hal_construct_ProbeRsp(_adapter *padapter, u8 *pframe, u32 *pLength,
 				u8 *StaAddr, BOOLEAN bHideSSID)
 {
 	struct rtw_ieee80211_hdr	*pwlanhdr;

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -570,7 +570,7 @@ static inline void hal_init_pg_txpwr_info_5g(_adapter *adapter, TxPowerInfo5G *p
 #define LOAD_PG_TXPWR_WARN_COND(_txpwr_src) (_txpwr_src > PG_TXPWR_SRC_PG_DATA)
 #endif
 
-u16 hal_load_pg_txpwr_info_path_2g(
+static u16 hal_load_pg_txpwr_info_path_2g(
 	_adapter *adapter,
 	TxPowerInfo24G	*pwr_info,
 	u32 path,
@@ -700,7 +700,7 @@ exit:
 	return offset;
 }
 
-u16 hal_load_pg_txpwr_info_path_5g(
+static u16 hal_load_pg_txpwr_info_path_5g(
 	_adapter *adapter,
 	TxPowerInfo5G	*pwr_info,
 	u32 path,
@@ -861,7 +861,7 @@ exit:
 	return offset;
 }
 
-void hal_load_pg_txpwr_info(
+static void hal_load_pg_txpwr_info(
 	_adapter *adapter,
 	TxPowerInfo24G *pwr_info_2g,
 	TxPowerInfo5G *pwr_info_5g,
@@ -1208,7 +1208,7 @@ void dump_hal_txpwr_info_5g(void *sel, _adapter *adapter, u8 rfpath_num, u8 max_
 *
 * Return dBm or -1 for undefined
 */
-s8 rtw_regsty_get_target_tx_power(
+static s8 rtw_regsty_get_target_tx_power(
 	IN	PADAPTER		Adapter,
 	IN	u8				Band,
 	IN	u8				RfPath,
@@ -1252,7 +1252,7 @@ s8 rtw_regsty_get_target_tx_power(
 	return value;
 }
 
-bool rtw_regsty_chk_target_tx_power_valid(_adapter *adapter)
+static bool rtw_regsty_chk_target_tx_power_valid(_adapter *adapter)
 {
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
@@ -1333,7 +1333,7 @@ PHY_GetTxPowerByRateBase(
 	return value;
 }
 
-VOID
+static VOID
 phy_SetTxPowerByRateBase(
 	IN	PADAPTER		Adapter,
 	IN	u8				Band,
@@ -1456,7 +1456,7 @@ static void phy_txpwr_by_rate_chk_for_path_dup(_adapter *adapter)
 	}
 }
 
-VOID
+static VOID
 phy_StoreTxPowerByRateBase(
 	IN	PADAPTER	pAdapter
 )
@@ -1898,7 +1898,7 @@ PHY_GetRateValuesOfTxPowerByRate(
 	};
 }
 
-void
+static void
 PHY_StoreTxPowerByRateNew(
 	IN	PADAPTER	pAdapter,
 	IN	u32			Band,
@@ -1982,7 +1982,7 @@ PHY_StoreTxPowerByRate(
 
 }
 
-VOID
+static VOID
 phy_ConvertTxPowerByRateInDbmToRelativeValues(
 	IN	PADAPTER	pAdapter
 )
@@ -2114,7 +2114,7 @@ exit:
 	return;
 }
 
-BOOLEAN
+static BOOLEAN
 phy_GetChnlIndex(
 	IN	u8	Channel,
 	OUT u8	*ChannelIdx
@@ -2790,7 +2790,7 @@ PHY_SetTxPowerIndexByRateArray(
 	}
 }
 
-s8
+static s8
 phy_GetWorldWideLimit(
 	s8 *LimitTable
 )
@@ -2806,7 +2806,7 @@ phy_GetWorldWideLimit(
 	return min;
 }
 
-s8
+static s8
 phy_GetChannelIndexOfTxPowerLimit(
 	IN	u8			Band,
 	IN	u8			Channel
@@ -3293,7 +3293,7 @@ PHY_GetTxPowerLimitOriginal(
 #endif
 
 
-VOID
+static VOID
 phy_CrossReferenceHTAndVHTTxPowerLimit(
 	IN	PADAPTER			pAdapter
 )
@@ -4373,7 +4373,7 @@ phy_ConfigBBWithParaFile(
 	return rtStatus;
 }
 
-VOID
+static VOID
 phy_DecryptBBPgParaFile(
 	PADAPTER		Adapter,
 	char			*buffer
@@ -4411,7 +4411,7 @@ phy_DecryptBBPgParaFile(
 	}
 }
 
-int
+static int
 phy_ParseBBPgParaFile(
 	PADAPTER		Adapter,
 	char			*buffer
@@ -4921,7 +4921,7 @@ PHY_ConfigRFWithParaFile(
 	return rtStatus;
 }
 
-VOID
+static VOID
 initDeltaSwingIndexTables(
 	PADAPTER	Adapter,
 	char		*Band,
@@ -5109,7 +5109,7 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 	return rtStatus;
 }
 
-int
+static int
 phy_ParsePowerLimitTableFile(
 	PADAPTER		Adapter,
 	char			*buffer

--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -22,7 +22,7 @@
 #include <hal_data.h>
 
 /* A mapping from HalData to ODM. */
-ODM_BOARD_TYPE_E boardType(u8 InterfaceSel)
+static ODM_BOARD_TYPE_E boardType(u8 InterfaceSel)
 {
 	ODM_BOARD_TYPE_E        board	= ODM_BOARD_DEFAULT;
 

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -169,7 +169,7 @@ void rtw_hal_power_off(_adapter *padapter)
 }
 
 
-void rtw_hal_init_opmode(_adapter *padapter)
+static void rtw_hal_init_opmode(_adapter *padapter)
 {
 	NDIS_802_11_NETWORK_INFRASTRUCTURE networkType = Ndis802_11InfrastructureMax;
 	struct  mlme_priv *pmlmepriv = &(padapter->mlmepriv);

--- a/hal/led/hal_sdio_led.c
+++ b/hal/led/hal_sdio_led.c
@@ -26,7 +26,7 @@
  *		Implementation of LED blinking behavior.
  *		It toggle off LED and schedule corresponding timer if necessary.
  *   */
-void
+static void
 SwLedBlink(
 	PLED_SDIO			pLed
 )
@@ -112,7 +112,7 @@ SwLedBlink(
 	}
 }
 
-void
+static void
 SwLedBlink1(
 	PLED_SDIO			pLed
 )
@@ -285,7 +285,7 @@ SwLedBlink1(
 
 }
 
-void
+static void
 SwLedBlink2(
 	PLED_SDIO			pLed
 )
@@ -371,7 +371,7 @@ SwLedBlink2(
 
 }
 
-void
+static void
 SwLedBlink3(
 	PLED_SDIO			pLed
 )
@@ -497,7 +497,7 @@ SwLedBlink3(
 }
 
 
-void
+static void
 SwLedBlink4(
 	PLED_SDIO			pLed
 )
@@ -651,7 +651,7 @@ SwLedBlink4(
 
 }
 
-void
+static void
 SwLedBlink5(
 	PLED_SDIO			pLed
 )
@@ -741,7 +741,7 @@ SwLedBlink5(
 
 }
 
-void
+static void
 SwLedBlink6(
 	PLED_SDIO			pLed
 )
@@ -820,7 +820,7 @@ void BlinkHandler(PLED_SDIO	pLed)
  *		it just schedules to corresponding BlinkWorkItem/led_blink_hdl
  *   */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-void BlinkTimerCallback(struct timer_list *t)
+static void BlinkTimerCallback(struct timer_list *t)
 #else
 void BlinkTimerCallback(void *data)
 #endif

--- a/hal/phydm/phydm_features.h
+++ b/hal/phydm/phydm_features.h
@@ -19,7 +19,7 @@
  ******************************************************************************/
 
 #ifndef	__PHYDM_FEATURES_H__
-#define __PHYDM_FEATURES
+#define __PHYDM_FEATURES_H__
 
 
 #if (DM_ODM_SUPPORT_TYPE == ODM_WIN)

--- a/hal/phydm/phydm_hwconfig.c
+++ b/hal/phydm/phydm_hwconfig.c
@@ -64,7 +64,7 @@
 #define GET_VERSION(ic, txt) GET_VERSION_MP(ic, txt)
 #endif
 
-u1Byte
+static u1Byte
 odm_QueryRxPwrPercentage(
 	IN		s1Byte		AntPower
 	)
@@ -82,7 +82,7 @@ odm_QueryRxPwrPercentage(
 // 2012/01/12 MH MOve some signal strength smooth method to MP HAL layer.
 // IF other SW team do not support the feature, remove this section.??
 //
-s4Byte
+static s4Byte
 odm_SignalScaleMapping_92CSeries_patch_RT_CID_819x_Lenovo(	
 	IN OUT PDM_ODM_T pDM_Odm,
 	s4Byte CurrSig 
@@ -120,7 +120,7 @@ odm_SignalScaleMapping_92CSeries_patch_RT_CID_819x_Lenovo(
 	return RetSig;
 }
 
-s4Byte
+static s4Byte
 odm_SignalScaleMapping_92CSeries_patch_RT_CID_819x_Netcore(	
 	IN OUT PDM_ODM_T pDM_Odm,
 	s4Byte CurrSig 
@@ -159,7 +159,7 @@ odm_SignalScaleMapping_92CSeries_patch_RT_CID_819x_Netcore(
 }
 
 
-s4Byte
+static s4Byte
 odm_SignalScaleMapping_92CSeries(	
 	IN OUT PDM_ODM_T pDM_Odm,
 	IN s4Byte CurrSig 
@@ -538,7 +538,7 @@ odm_Cfo(
 	return ret_val;
 }
 
-u1Byte
+static u1Byte
 phydm_rate_to_num_ss(
 	IN OUT	PDM_ODM_T		pDM_Odm,
 	IN		u1Byte			DataRate
@@ -677,7 +677,7 @@ odm_CCKRSSI_8188E(
 }
 #endif
 
-VOID
+static VOID
 odm_RxPhyStatus92CSeries_Parsing(
 	IN OUT	PDM_ODM_T					pDM_Odm,
 	OUT		PODM_PHY_INFO_T			pPhyInfo,		
@@ -1501,7 +1501,7 @@ odm_Init_RSSIForDM(
 
 }
 
-VOID
+static VOID
 odm_Process_RSSIForDM(	
 	IN OUT	PDM_ODM_T					pDM_Odm,
 	OUT		PODM_PHY_INFO_T			pPhyInfo,
@@ -1827,7 +1827,7 @@ odm_Process_RSSIForDM(
 //
 // Endianness before calling this API
 //
-VOID
+static VOID
 ODM_PhyStatusQuery_92CSeries(
 	IN OUT	PDM_ODM_T					pDM_Odm,
 	OUT		PODM_PHY_INFO_T				pPhyInfo,
@@ -2979,7 +2979,7 @@ ODM_GetHWImgVersion(
 /* For 8822B only!! need to move to FW finally */
 /*==============================================*/
 
-VOID
+static VOID
 phydm_ResetPhyInfo(
 	IN		PDM_ODM_T					pPhydm,
 	OUT		PODM_PHY_INFO_T			pPhyInfo
@@ -3010,7 +3010,7 @@ phydm_ResetPhyInfo(
 #endif
 }
 
-VOID
+static VOID
 phydm_SetPerPathPhyInfo(
 	IN		u1Byte							RxPath,
 	IN		s1Byte							RxPwr,
@@ -3062,7 +3062,7 @@ phydm_SetPerPathPhyInfo(
 */
 }
 
-VOID
+static VOID
 phydm_SetCommonPhyInfo(
 	IN		s1Byte							RxPower,
 	IN		u1Byte							channel,
@@ -3097,7 +3097,7 @@ phydm_SetCommonPhyInfo(
 */
 }
 
-VOID
+static VOID
 phydm_GetRxPhyStatusType0(
 	IN		PDM_ODM_T						pDM_Odm,
 	IN		pu1Byte							pPhyStatus,
@@ -3190,7 +3190,7 @@ phydm_GetRxPhyStatusType0(
 */
 }
 
-VOID
+static VOID
 phydm_GetRxPhyStatusType1(
 	IN		PDM_ODM_T						pDM_Odm,
 	IN		pu1Byte							pPhyStatus,
@@ -3311,7 +3311,7 @@ phydm_GetRxPhyStatusType1(
 */
 }
 
-VOID
+static VOID
 phydm_GetRxPhyStatusType2(
 	IN		PDM_ODM_T						pDM_Odm,
 	IN		pu1Byte							pPhyStatus,
@@ -3417,7 +3417,7 @@ phydm_GetRxPhyStatusType2(
 */
 }
 
-VOID
+static VOID
 phydm_GetRxPhyStatusType5(
 	IN		pu1Byte				pPhyStatus
 )
@@ -3433,7 +3433,7 @@ phydm_GetRxPhyStatusType5(
 */
 }
 
-VOID
+static VOID
 phydm_Process_RSSIForDMNewType(	
 	IN OUT	PDM_ODM_T					pDM_Odm,
 	IN		PODM_PHY_INFO_T			pPhyInfo,

--- a/hal/phydm/phydm_interface.c
+++ b/hal/phydm/phydm_interface.c
@@ -620,7 +620,7 @@ ODM_ReleaseTimer(
 }
 
 
-u1Byte
+static u1Byte
 phydm_trans_h2c_id(
 	IN	PDM_ODM_T	pDM_Odm,
 	IN	u1Byte		phydm_h2c_id

--- a/hal/phydm/phydm_kfree.h
+++ b/hal/phydm/phydm_kfree.h
@@ -20,7 +20,7 @@
  ******************************************************************************/
 
 #ifndef	__PHYDMKFREE_H__
-#define    __PHYDKFREE_H__
+#define    __PHYDMKFREE_H__
 
 #define KFREE_VERSION	"1.0"
 

--- a/hal/rtl8723d/rtl8723d_cmd.c
+++ b/hal/rtl8723d/rtl8723d_cmd.c
@@ -518,7 +518,7 @@ void rtl8723d_set_FwMacIdConfig_cmd(_adapter *padapter, u8 mac_id, u8 raid, u8 b
 
 }
 
-void rtl8723d_set_FwRssiSetting_cmd(_adapter *padapter, u8 *param)
+static void rtl8723d_set_FwRssiSetting_cmd(_adapter *padapter, u8 *param)
 {
 	u8 u1H2CRssiSettingParm[H2C_RSSI_SETTING_LEN] = {0};
 	u8 mac_id = *param;
@@ -538,7 +538,7 @@ void rtl8723d_set_FwRssiSetting_cmd(_adapter *padapter, u8 *param)
 
 }
 
-void rtl8723d_set_FwAPReqRPT_cmd(PADAPTER padapter, u32 need_ack)
+static void rtl8723d_set_FwAPReqRPT_cmd(PADAPTER padapter, u32 need_ack)
 {
 	u8 u1H2CApReqRptParm[H2C_AP_REQ_TXRPT_LEN] = {0};
 	u8 macid1 = 1, macid2 = 0;

--- a/hal/rtl8723d/rtl8723d_hal_init.c
+++ b/hal/rtl8723d/rtl8723d_hal_init.c
@@ -2934,7 +2934,7 @@ static void rtl8723d_SetBeaconRelatedRegisters(PADAPTER padapter)
 	rtw_write8(padapter, bcn_ctrl_reg, val8);
 }
 
-void hal_notch_filter_8723d(_adapter *adapter, bool enable)
+static void hal_notch_filter_8723d(_adapter *adapter, bool enable)
 {
 	if (enable) {
 		RTW_INFO("Enable notch filter\n");
@@ -2945,7 +2945,7 @@ void hal_notch_filter_8723d(_adapter *adapter, bool enable)
 	}
 }
 
-u8 rtl8723d_MRateIdxToARFRId(PADAPTER padapter, u8 rate_idx)
+static u8 rtl8723d_MRateIdxToARFRId(PADAPTER padapter, u8 rate_idx)
 {
 	u8 ret = 0;
 	RT_RF_TYPE_DEF_E rftype = (RT_RF_TYPE_DEF_E)GET_RF_TYPE(padapter);
@@ -3007,7 +3007,7 @@ u8 rtl8723d_MRateIdxToARFRId(PADAPTER padapter, u8 rate_idx)
 	return ret;
 }
 
-void UpdateHalRAMask8723D(PADAPTER padapter, struct sta_info *psta, u32 mac_id, u8 rssi_level)
+static void UpdateHalRAMask8723D(PADAPTER padapter, struct sta_info *psta, u32 mac_id, u8 rssi_level)
 {
 	u32	mask, rate_bitmap = 0, ratr_bitmap_msb = 0;
 	u8	disable_cck_rate = FALSE, MimoPs_enable = FALSE;
@@ -3307,7 +3307,7 @@ s32 rtl8723d_InitLLTTable(PADAPTER padapter)
 }
 
 #if defined(CONFIG_USB_HCI) || defined(CONFIG_SDIO_HCI) || defined(CONFIG_GSPI_HCI)
-void _DisableGPIO(PADAPTER	padapter)
+static void _DisableGPIO(PADAPTER	padapter)
 {
 	/***************************************
 	j. GPIO_PIN_CTRL 0x44[31:0]=0x000
@@ -3343,7 +3343,7 @@ void _DisableGPIO(PADAPTER	padapter)
 
 } /* end of _DisableGPIO() */
 
-void _DisableRFAFEAndResetBB8723D(PADAPTER padapter)
+static void _DisableRFAFEAndResetBB8723D(PADAPTER padapter)
 {
 	/**************************************
 	a.	TXPAUSE 0x522[7:0] = 0xFF
@@ -3374,12 +3374,12 @@ void _DisableRFAFEAndResetBB8723D(PADAPTER padapter)
 
 }
 
-void _DisableRFAFEAndResetBB(PADAPTER padapter)
+static void _DisableRFAFEAndResetBB(PADAPTER padapter)
 {
 	_DisableRFAFEAndResetBB8723D(padapter);
 }
 
-void _ResetDigitalProcedure1_8723D(PADAPTER padapter, BOOLEAN bWithoutHWSM)
+static void _ResetDigitalProcedure1_8723D(PADAPTER padapter, BOOLEAN bWithoutHWSM)
 {
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
 
@@ -3487,12 +3487,12 @@ void _ResetDigitalProcedure1_8723D(PADAPTER padapter, BOOLEAN bWithoutHWSM)
 
 }
 
-void _ResetDigitalProcedure1(PADAPTER padapter, BOOLEAN bWithoutHWSM)
+static void _ResetDigitalProcedure1(PADAPTER padapter, BOOLEAN bWithoutHWSM)
 {
 	_ResetDigitalProcedure1_8723D(padapter, bWithoutHWSM);
 }
 
-void _ResetDigitalProcedure2(PADAPTER padapter)
+static void _ResetDigitalProcedure2(PADAPTER padapter)
 {
 	/* HAL_DATA_TYPE		*pHalData	= GET_HAL_DATA(padapter);
 	*****************************
@@ -3506,7 +3506,7 @@ void _ResetDigitalProcedure2(PADAPTER padapter)
 	rtw_write8(padapter, REG_SYS_ISO_CTRL + 1, 0x82); /* modify to 0x82 by Scott. */
 }
 
-void _DisableAnalog(PADAPTER padapter, BOOLEAN bWithoutHWSM)
+static void _DisableAnalog(PADAPTER padapter, BOOLEAN bWithoutHWSM)
 {
 	HAL_DATA_TYPE	*pHalData	= GET_HAL_DATA(padapter);
 	u16 value16 = 0;
@@ -5162,7 +5162,7 @@ void CCX_FwC2HTxRpt_8723d(PADAPTER padapter, u8 *pdata, u8 len)
 #endif
 }
 
-s32 c2h_handler_8723d(_adapter *adapter, u8 id, u8 seq, u8 plen, u8 *payload)
+static s32 c2h_handler_8723d(_adapter *adapter, u8 id, u8 seq, u8 plen, u8 *payload)
 {
 	s32 ret = _SUCCESS;
 
@@ -5728,7 +5728,7 @@ struct bcn_qinfo_8723d {
 	u16 pkt_num:8;
 };
 
-void dump_qinfo_8723d(void *sel, struct qinfo_8723d *info, const char *tag)
+static void dump_qinfo_8723d(void *sel, struct qinfo_8723d *info, const char *tag)
 {
 	/* if (info->pkt_num) */
 	RTW_PRINT_SEL(sel, "%shead:0x%02x, tail:0x%02x, pkt_num:%u, macid:%u, ac:%u\n"
@@ -5736,14 +5736,14 @@ void dump_qinfo_8723d(void *sel, struct qinfo_8723d *info, const char *tag)
 		info->pkt_num, info->macid, info->ac);
 }
 
-void dump_bcn_qinfo_8723d(void *sel, struct bcn_qinfo_8723d *info, const char *tag)
+static void dump_bcn_qinfo_8723d(void *sel, struct bcn_qinfo_8723d *info, const char *tag)
 {
 	/* if (info->pkt_num) */
 	RTW_PRINT_SEL(sel, "%shead:0x%02x, pkt_num:%u\n"
 		      , tag ? tag : "", info->head, info->pkt_num);
 }
 
-void dump_mac_qinfo_8723d(void *sel, _adapter *adapter)
+static void dump_mac_qinfo_8723d(void *sel, _adapter *adapter)
 {
 	u32 q0_info;
 	u32 q1_info;
@@ -5896,7 +5896,7 @@ u8 SetHalDefVar8723D(PADAPTER padapter, HAL_DEF_VARIABLE variable, void *pval)
 	return bResult;
 }
 
-void hal_ra_info_dump(_adapter *padapter , void *sel)
+static void hal_ra_info_dump(_adapter *padapter , void *sel)
 {
 	int i;
 	u8 mac_id;

--- a/hal/rtl8723d/rtl8723d_phycfg.c
+++ b/hal/rtl8723d/rtl8723d_phycfg.c
@@ -802,7 +802,7 @@ PHY_SetTxPowerIndex_8723D(
 	}
 }
 
-u8
+static u8
 phy_GetCurrentTxNum_8723D(
 	IN	PADAPTER		pAdapter
 )
@@ -890,7 +890,7 @@ PHY_GetTxPowerLevel8723D(
 
 
 /* <20160217, Jessica> A workaround to eliminate the 2472MHz & 2484MHz spur of 8723D. */
-VOID
+static VOID
 phy_SpurCalibration_8723D(
 	IN	PADAPTER					pAdapter,
 	IN	u1Byte						ToChannel,
@@ -978,7 +978,7 @@ phy_SpurCalibration_8723D(
 	ODM_SetBBReg(pDM_Odm, 0xD2C, BIT(28), 0x0);                    /* disable CSI mask */
 }
 
-VOID
+static VOID
 phy_SetRegBW_8723D(
 	IN	PADAPTER		Adapter,
 	CHANNEL_WIDTH	CurrentBW
@@ -1009,7 +1009,7 @@ phy_SetRegBW_8723D(
 	}
 }
 
-u8
+static u8
 phy_GetSecondaryChnl_8723D(
 	IN	PADAPTER	Adapter
 )
@@ -1045,7 +1045,7 @@ phy_GetSecondaryChnl_8723D(
 	return (SCSettingOf40 << 4) | SCSettingOf20;
 }
 
-void
+static void
 phy_PostSetBwMode8723D(
 	IN PADAPTER padapter
 )
@@ -1099,7 +1099,7 @@ phy_PostSetBwMode8723D(
 	PHY_RF6052SetBandwidth8723D(padapter, pHalData->CurrentChannelBW);
 }
 
-VOID
+static VOID
 phy_SwChnl8723D(
 	IN	PADAPTER					pAdapter
 )
@@ -1144,7 +1144,7 @@ phy_SwChnl8723D(
 	RTW_INFO("===>phy_SwChnl8723D: Channel = %d\n", channelToSW);
 }
 
-VOID
+static VOID
 phy_SwChnlAndSetBwMode8723D(
 	IN  PADAPTER		Adapter
 )
@@ -1176,7 +1176,7 @@ phy_SwChnlAndSetBwMode8723D(
 	PHY_SetTxPowerLevel8723D(Adapter, pHalData->CurrentChannel);
 }
 
-VOID
+static VOID
 PHY_HandleSwChnlAndSetBW8723D(
 	IN	PADAPTER			Adapter,
 	IN	BOOLEAN				bSwitchChannel,

--- a/hal/rtl8723d/sdio/rtl8723ds_led.c
+++ b/hal/rtl8723d/sdio/rtl8723ds_led.c
@@ -38,7 +38,7 @@
  *	Description:
  *		Turn on LED according to LedPin specified.
  *   */
-void
+static void
 SwLedOn_8723DS(
 	_adapter			*padapter,
 	PLED_SDIO		pLed
@@ -59,7 +59,7 @@ SwLedOn_8723DS(
  *	Description:
  *		Turn off LED according to LedPin specified.
  *   */
-void
+static void
 SwLedOff_8723DS(
 	_adapter			*padapter,
 	PLED_SDIO		pLed

--- a/hal/rtl8723d/sdio/rtl8723ds_xmit.c
+++ b/hal/rtl8723d/sdio/rtl8723ds_xmit.c
@@ -456,7 +456,7 @@ static s32 xmit_xmitframes(PADAPTER padapter, struct xmit_priv *pxmitpriv)
  *	_SUCCESS	ok
  *	_FAIL		something error
  */
-s32 rtl8723ds_xmit_handler(PADAPTER padapter)
+static s32 rtl8723ds_xmit_handler(PADAPTER padapter)
 {
 	struct xmit_priv *pxmitpriv;
 	s32 ret;

--- a/hal/rtl8723d/sdio/sdio_halinit.c
+++ b/hal/rtl8723d/sdio/sdio_halinit.c
@@ -61,7 +61,7 @@ static u8 CardEnable(PADAPTER padapter)
 }
 
 /* static */
-u32 _InitPowerOn_8723DS(PADAPTER padapter)
+static u32 _InitPowerOn_8723DS(PADAPTER padapter)
 {
 	u8 value8;
 	u16 value16;
@@ -451,12 +451,12 @@ static void _InitTransferPageSize(PADAPTER padapter)
 	rtw_write8(padapter, REG_PBP, value8);
 }
 
-void _InitDriverInfoSize(PADAPTER padapter, u8 drvInfoSize)
+static void _InitDriverInfoSize(PADAPTER padapter, u8 drvInfoSize)
 {
 	rtw_write8(padapter, REG_RX_DRVINFO_SZ, drvInfoSize);
 }
 
-void _InitNetworkType(PADAPTER padapter)
+static void _InitNetworkType(PADAPTER padapter)
 {
 	u32 value32;
 
@@ -469,7 +469,7 @@ void _InitNetworkType(PADAPTER padapter)
 	rtw_write32(padapter, REG_CR, value32);
 }
 
-void _InitWMACSetting(PADAPTER padapter)
+static void _InitWMACSetting(PADAPTER padapter)
 {
 	PHAL_DATA_TYPE pHalData;
 	u16 value16;
@@ -507,7 +507,7 @@ void _InitWMACSetting(PADAPTER padapter)
 	rtw_write16(padapter, REG_RXFLTMAP0, value16);
 }
 
-void _InitAdaptiveCtrl(PADAPTER padapter)
+static void _InitAdaptiveCtrl(PADAPTER padapter)
 {
 	u16	value16;
 	u32	value32;
@@ -530,7 +530,7 @@ void _InitAdaptiveCtrl(PADAPTER padapter)
 	rtw_write16(padapter, REG_RL, value16);
 }
 
-void _InitEDCA(PADAPTER padapter)
+static void _InitEDCA(PADAPTER padapter)
 {
 	/* Set Spec SIFS (used in NAV) */
 	rtw_write16(padapter, REG_SPEC_SIFS, 0x100a);
@@ -549,7 +549,7 @@ void _InitEDCA(PADAPTER padapter)
 	rtw_write32(padapter, REG_EDCA_VO_PARAM, 0x002FA226);
 }
 
-void _InitRateFallback(PADAPTER padapter)
+static void _InitRateFallback(PADAPTER padapter)
 {
 	/* Set Data Auto Rate Fallback Retry Count register. */
 	rtw_write32(padapter, REG_DARFRC, 0x00000000);
@@ -559,7 +559,7 @@ void _InitRateFallback(PADAPTER padapter)
 
 }
 
-void _InitRetryFunction(PADAPTER padapter)
+static void _InitRetryFunction(PADAPTER padapter)
 {
 	u8	value8;
 
@@ -594,7 +594,7 @@ static void HalRxAggr8723DSdio(PADAPTER padapter)
 
 }
 
-void sdio_AggSettingRxUpdate(PADAPTER padapter)
+static void sdio_AggSettingRxUpdate(PADAPTER padapter)
 {
 	HAL_DATA_TYPE *pHalData;
 	u8 val8;
@@ -619,7 +619,7 @@ void sdio_AggSettingRxUpdate(PADAPTER padapter)
 	rtw_write8(padapter, REG_RXDMA_MODE_CTRL_8723D, valueRxAggCtrl);/* RxAggLowThresh = 4*1K */
 }
 
-void _initSdioAggregationSetting(PADAPTER padapter)
+static void _initSdioAggregationSetting(PADAPTER padapter)
 {
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(padapter);
 
@@ -656,7 +656,7 @@ static void _RXAggrSwitch(PADAPTER padapter, u8 enable)
 	rtw_write8(padapter, REG_RXDMA_MODE_CTRL_8723D, valueRxAggCtrl);
 }
 
-void _InitOperationMode(PADAPTER padapter)
+static void _InitOperationMode(PADAPTER padapter)
 {
 	PHAL_DATA_TYPE pHalData;
 	struct mlme_ext_priv *pmlmeext;
@@ -729,7 +729,7 @@ void _InitOperationMode(PADAPTER padapter)
 
 }
 
-void _InitInterrupt(PADAPTER padapter)
+static void _InitInterrupt(PADAPTER padapter)
 {
 	/* HISR - turn all off */
 	rtw_write32(padapter, REG_HISR, 0);
@@ -748,7 +748,7 @@ void _InitInterrupt(PADAPTER padapter)
 	InitSysInterrupt8723DSdio(padapter);
 }
 
-void _InitRDGSetting(PADAPTER padapter)
+static void _InitRDGSetting(PADAPTER padapter)
 {
 	rtw_write8(padapter, REG_RD_CTRL, 0xFF);
 	rtw_write16(padapter, REG_RD_NAV_NXT, 0x200);
@@ -818,7 +818,7 @@ static void _InitPABias(PADAPTER padapter)
 	}
 }
 
-VOID _InitBBRegBackup_8723DS(PADAPTER	Adapter)
+static VOID _InitBBRegBackup_8723DS(PADAPTER	Adapter)
 {
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA(Adapter);
 	u8	i;
@@ -1667,7 +1667,7 @@ static void ReadAdapterInfo8723DS(PADAPTER padapter)
  * If variable not handled here,
  * some variables will be processed in SetHwReg8723D()
  */
-void SetHwReg8723DS(PADAPTER padapter, u8 variable, u8 *val)
+static void SetHwReg8723DS(PADAPTER padapter, u8 variable, u8 *val)
 {
 	PHAL_DATA_TYPE pHalData;
 	u8 val8;
@@ -1763,7 +1763,7 @@ void SetHwReg8723DS(PADAPTER padapter, u8 variable, u8 *val)
  * If variable not handled here,
  * some variables will be processed in GetHwReg8723D()
  */
-void GetHwReg8723DS(PADAPTER padapter, u8 variable, u8 *val)
+static void GetHwReg8723DS(PADAPTER padapter, u8 variable, u8 *val)
 {
 	PHAL_DATA_TYPE pHalData = GET_HAL_DATA(padapter);
 
@@ -1789,7 +1789,7 @@ void GetHwReg8723DS(PADAPTER padapter, u8 variable, u8 *val)
  *	Description:
  *		Query setting of specified variable.
  *   */
-u8
+static u8
 GetHalDefVar8723DSDIO(
 	IN	PADAPTER				Adapter,
 	IN	HAL_DEF_VARIABLE		eVariable,
@@ -1829,7 +1829,7 @@ GetHalDefVar8723DSDIO(
  *	Description:
  *		Change default setting of specified variable.
  *   */
-u8
+static u8
 SetHalDefVar8723DSDIO(
 	IN	PADAPTER				Adapter,
 	IN	HAL_DEF_VARIABLE		eVariable,

--- a/hal/rtl8723d/sdio/sdio_ops.c
+++ b/hal/rtl8723d/sdio/sdio_ops.c
@@ -156,7 +156,7 @@ static u32 _cvrt2ftaddr(const u32 addr, u8 *pdeviceId, u16 *poffset)
 	return ftaddr;
 }
 
-u8 sdio_read8(struct intf_hdl *pintfhdl, u32 addr)
+static u8 sdio_read8(struct intf_hdl *pintfhdl, u32 addr)
 {
 	u32 ftaddr;
 	u8 val;
@@ -168,7 +168,7 @@ u8 sdio_read8(struct intf_hdl *pintfhdl, u32 addr)
 	return val;
 }
 
-u16 sdio_read16(struct intf_hdl *pintfhdl, u32 addr)
+static u16 sdio_read16(struct intf_hdl *pintfhdl, u32 addr)
 {
 	u32 ftaddr;
 	u16 val;
@@ -182,7 +182,7 @@ u16 sdio_read16(struct intf_hdl *pintfhdl, u32 addr)
 	return val;
 }
 
-u32 sdio_read32(struct intf_hdl *pintfhdl, u32 addr)
+static u32 sdio_read32(struct intf_hdl *pintfhdl, u32 addr)
 {
 	PADAPTER padapter;
 	u8 bMacPwrCtrlOn;
@@ -248,7 +248,7 @@ u32 sdio_read32(struct intf_hdl *pintfhdl, u32 addr)
 	return val;
 }
 
-s32 sdio_readN(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *pbuf)
+static s32 sdio_readN(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *pbuf)
 {
 	PADAPTER padapter;
 	u8 bMacPwrCtrlOn;
@@ -299,7 +299,7 @@ s32 sdio_readN(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *pbuf)
 	return err;
 }
 
-s32 sdio_write8(struct intf_hdl *pintfhdl, u32 addr, u8 val)
+static s32 sdio_write8(struct intf_hdl *pintfhdl, u32 addr, u8 val)
 {
 	u32 ftaddr;
 	s32 err;
@@ -312,7 +312,7 @@ s32 sdio_write8(struct intf_hdl *pintfhdl, u32 addr, u8 val)
 	return err;
 }
 
-s32 sdio_write16(struct intf_hdl *pintfhdl, u32 addr, u16 val)
+static s32 sdio_write16(struct intf_hdl *pintfhdl, u32 addr, u16 val)
 {
 	u32 ftaddr;
 	u8 shift;
@@ -326,7 +326,7 @@ s32 sdio_write16(struct intf_hdl *pintfhdl, u32 addr, u16 val)
 	return err;
 }
 
-s32 sdio_write32(struct intf_hdl *pintfhdl, u32 addr, u32 val)
+static s32 sdio_write32(struct intf_hdl *pintfhdl, u32 addr, u32 val)
 {
 	PADAPTER padapter;
 	u8 bMacPwrCtrlOn;
@@ -392,7 +392,7 @@ s32 sdio_write32(struct intf_hdl *pintfhdl, u32 addr, u32 val)
 	return err;
 }
 
-s32 sdio_writeN(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *pbuf)
+static s32 sdio_writeN(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *pbuf)
 {
 	PADAPTER padapter;
 	u8 bMacPwrCtrlOn;
@@ -446,7 +446,7 @@ s32 sdio_writeN(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *pbuf)
 	return err;
 }
 
-u8 sdio_f0_read8(struct intf_hdl *pintfhdl, u32 addr)
+static u8 sdio_f0_read8(struct intf_hdl *pintfhdl, u32 addr)
 {
 	u32 ftaddr;
 	u8 val;
@@ -457,7 +457,7 @@ u8 sdio_f0_read8(struct intf_hdl *pintfhdl, u32 addr)
 	return val;
 }
 
-void sdio_read_mem(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem)
+static void sdio_read_mem(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem)
 {
 	s32 err;
 
@@ -466,7 +466,7 @@ void sdio_read_mem(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *rmem)
 
 }
 
-void sdio_write_mem(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *wmem)
+static void sdio_write_mem(struct intf_hdl *pintfhdl, u32 addr, u32 cnt, u8 *wmem)
 {
 
 	sdio_writeN(pintfhdl, addr, cnt, wmem);
@@ -817,7 +817,7 @@ u8 SdioLocalCmd52Read1Byte(PADAPTER padapter, u32 addr)
 	return val;
 }
 
-u16 SdioLocalCmd52Read2Byte(PADAPTER padapter, u32 addr)
+static u16 SdioLocalCmd52Read2Byte(PADAPTER padapter, u32 addr)
 {
 	u16 val = 0;
 	struct intf_hdl *pintfhdl = &padapter->iopriv.intf;
@@ -830,7 +830,7 @@ u16 SdioLocalCmd52Read2Byte(PADAPTER padapter, u32 addr)
 	return val;
 }
 
-u32 SdioLocalCmd52Read4Byte(PADAPTER padapter, u32 addr)
+static u32 SdioLocalCmd52Read4Byte(PADAPTER padapter, u32 addr)
 {
 	u32 val = 0;
 	struct intf_hdl *pintfhdl = &padapter->iopriv.intf;
@@ -843,7 +843,7 @@ u32 SdioLocalCmd52Read4Byte(PADAPTER padapter, u32 addr)
 	return val;
 }
 
-u32 SdioLocalCmd53Read4Byte(PADAPTER padapter, u32 addr)
+static u32 SdioLocalCmd53Read4Byte(PADAPTER padapter, u32 addr)
 {
 
 	u8 bMacPwrCtrlOn;
@@ -874,7 +874,7 @@ void SdioLocalCmd52Write1Byte(PADAPTER padapter, u32 addr, u8 v)
 	sd_cmd52_write(pintfhdl, addr, 1, &v);
 }
 
-void SdioLocalCmd52Write2Byte(PADAPTER padapter, u32 addr, u16 v)
+static void SdioLocalCmd52Write2Byte(PADAPTER padapter, u32 addr, u16 v)
 {
 	struct intf_hdl *pintfhdl = &padapter->iopriv.intf;
 
@@ -883,7 +883,7 @@ void SdioLocalCmd52Write2Byte(PADAPTER padapter, u32 addr, u16 v)
 	sd_cmd52_write(pintfhdl, addr, 2, (u8 *)&v);
 }
 
-void SdioLocalCmd52Write4Byte(PADAPTER padapter, u32 addr, u32 v)
+static void SdioLocalCmd52Write4Byte(PADAPTER padapter, u32 addr, u32 v)
 {
 	struct intf_hdl *pintfhdl = &padapter->iopriv.intf;
 
@@ -1134,7 +1134,7 @@ void ClearInterrupt8723DSdio(PADAPTER padapter)
  *
  *	Created by Roger, 2011.02.11.
  *   */
-void ClearSysInterrupt8723DSdio(PADAPTER padapter)
+static void ClearSysInterrupt8723DSdio(PADAPTER padapter)
 {
 	PHAL_DATA_TYPE pHalData;
 	u32 clear;
@@ -1250,7 +1250,7 @@ void DisableInterruptButCpwm28723DSdio(PADAPTER padapter)
  *
  *	Created by Roger, 2011.02.11.
  *   */
-void UpdateInterruptMask8723DSdio(PADAPTER padapter, u32 AddMSR, u32 RemoveMSR)
+static void UpdateInterruptMask8723DSdio(PADAPTER padapter, u32 AddMSR, u32 RemoveMSR)
 {
 	HAL_DATA_TYPE *pHalData;
 

--- a/include/custom_gpio.h
+++ b/include/custom_gpio.h
@@ -1,5 +1,5 @@
 #ifndef __CUSTOM_GPIO_H__
-#define __CUSTOM_GPIO_H___
+#define __CUSTOM_GPIO_H__
 
 #include <drv_conf.h>
 #include <osdep_service.h>

--- a/include/mlme_osdep.h
+++ b/include/mlme_osdep.h
@@ -29,4 +29,10 @@ extern void rtw_report_sec_ie(_adapter *adapter, u8 authmode, u8 *sec_ie);
 
 void rtw_reset_securitypriv(_adapter *adapter);
 
+
+/* -Wmissing-prototypes: cross-file declarations */
+void rtw_indicate_wx_disassoc_event(_adapter *padapter);
+void rtw_indicate_wx_assoc_event(_adapter *padapter);
+void indicate_wx_scan_complete_event(_adapter *padapter);
+
 #endif /* _MLME_OSDEP_H_ */

--- a/include/osdep_intf.h
+++ b/include/osdep_intf.h
@@ -134,4 +134,13 @@ int	rtw_gw_addr_query(_adapter *padapter);
 int rtw_suspend_common(_adapter *padapter);
 int rtw_resume_common(_adapter *padapter);
 
+
+/* -Wmissing-prototypes: cross-file declarations */
+int pm_netdev_close(struct net_device *pnetdev, u8 bnormal);
+int pm_netdev_open(struct net_device *pnetdev, u8 bnormal);
+void netdev_br_init(struct net_device *netdev);
+int rtw_resume_process(_adapter *padapter);
+void sdio_free_irq(struct dvobj_priv *dvobj);
+int sdio_alloc_irq(struct dvobj_priv *dvobj);
+
 #endif /* _OSDEP_INTF_H_ */

--- a/include/rtl8192e_sreset.h
+++ b/include/rtl8192e_sreset.h
@@ -17,8 +17,8 @@
  *
  *
  ******************************************************************************/
-#ifndef _RTL88812A_SRESET_H_
-#define _RTL8812A_SRESET_H_
+#ifndef _RTL8192E_SRESET_H_
+#define _RTL8192E_SRESET_H_
 
 #include <rtw_sreset.h>
 

--- a/include/rtl8812a_sreset.h
+++ b/include/rtl8812a_sreset.h
@@ -17,7 +17,7 @@
  *
  *
  ******************************************************************************/
-#ifndef _RTL88812A_SRESET_H_
+#ifndef _RTL8812A_SRESET_H_
 #define _RTL8812A_SRESET_H_
 
 #include <rtw_sreset.h>

--- a/include/rtl8814a_sreset.h
+++ b/include/rtl8814a_sreset.h
@@ -17,7 +17,7 @@
  *
  *
  ******************************************************************************/
-#ifndef _RTL88814A_SRESET_H_
+#ifndef _RTL8814A_SRESET_H_
 #define _RTL8814A_SRESET_H_
 
 #include <rtw_sreset.h>

--- a/include/rtw_br_ext.h
+++ b/include/rtw_br_ext.h
@@ -71,4 +71,12 @@ struct br_ext_info {
 
 void nat25_db_cleanup(_adapter *priv);
 
+
+/* -Wmissing-prototypes: cross-file declarations */
+void *scdb_findEntry(_adapter *priv, unsigned char *macAddr, unsigned char *ipAddr);
+void dhcp_flag_bcast(_adapter *priv, struct sk_buff *skb);
+int nat25_handle_frame(_adapter *priv, struct sk_buff *skb);
+int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method);
+void nat25_db_expire(_adapter *priv);
+
 #endif /* _RTW_BR_EXT_H_ */

--- a/include/rtw_btcoex.h
+++ b/include/rtw_btcoex.h
@@ -442,4 +442,10 @@ void rtw_btcoex_rx_ampdu_apply(PADAPTER);
 void rtw_btcoex_LPS_Enter(PADAPTER);
 void rtw_btcoex_LPS_Leave(PADAPTER);
 
+
+/* -Wmissing-prototypes: cross-file declarations */
+void rtw_btcoex_SetHciVersion(PADAPTER padapter, u16 hciVersion);
+void rtw_btcoex_SetBtPatchVersion(PADAPTER padapter, u16 btHciVer, u16 btPatchVer);
+void rtw_btcoex_StackUpdateProfileInfo(void);
+
 #endif /* __RTW_BTCOEX_H__ */

--- a/os_dep/linux/custom_gpio_linux.c
+++ b/os_dep/linux/custom_gpio_linux.c
@@ -19,6 +19,7 @@
  *
  ******************************************************************************/
 #include "drv_types.h"
+#include "custom_gpio.h"
 
 #ifdef CONFIG_PLATFORM_SPRD
 

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -189,35 +189,35 @@ static struct ieee80211_channel rtw_5ghz_a_channels[] = {
 };
 
 
-void rtw_2g_channels_init(struct ieee80211_channel *channels)
+static void rtw_2g_channels_init(struct ieee80211_channel *channels)
 {
 	_rtw_memcpy((void *)channels, (void *)rtw_2ghz_channels,
 		sizeof(struct ieee80211_channel) * RTW_2G_CHANNELS_NUM
 	);
 }
 
-void rtw_5g_channels_init(struct ieee80211_channel *channels)
+static void rtw_5g_channels_init(struct ieee80211_channel *channels)
 {
 	_rtw_memcpy((void *)channels, (void *)rtw_5ghz_a_channels,
 		sizeof(struct ieee80211_channel) * RTW_5G_CHANNELS_NUM
 	);
 }
 
-void rtw_2g_rates_init(struct ieee80211_rate *rates)
+static void rtw_2g_rates_init(struct ieee80211_rate *rates)
 {
 	_rtw_memcpy(rates, rtw_g_rates,
 		sizeof(struct ieee80211_rate) * RTW_G_RATES_NUM
 	);
 }
 
-void rtw_5g_rates_init(struct ieee80211_rate *rates)
+static void rtw_5g_rates_init(struct ieee80211_rate *rates)
 {
 	_rtw_memcpy(rates, rtw_a_rates,
 		sizeof(struct ieee80211_rate) * RTW_A_RATES_NUM
 	);
 }
 
-struct ieee80211_supported_band *rtw_spt_band_alloc(
+static struct ieee80211_supported_band *rtw_spt_band_alloc(
 	enum ieee80211_band band
 )
 {
@@ -262,7 +262,7 @@ exit:
 	return spt_band;
 }
 
-void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
+static void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
 {
 	u32 size = 0;
 
@@ -2033,7 +2033,7 @@ void rtw_cfg80211_unlink_bss(_adapter *padapter, struct wlan_network *pnetwork)
 }
 
 /* if target wps scan ongoing, target_ssid is filled */
-int rtw_cfg80211_is_target_wps_scan(struct cfg80211_scan_request *scan_req, struct cfg80211_ssid *target_ssid)
+static int rtw_cfg80211_is_target_wps_scan(struct cfg80211_scan_request *scan_req, struct cfg80211_ssid *target_ssid)
 {
 	int ret = 0;
 
@@ -4496,7 +4496,7 @@ static int	cfg80211_rtw_change_station(struct wiphy *wiphy,
 	return 0;
 }
 
-struct sta_info *rtw_sta_info_get_by_idx(const int idx, struct sta_priv *pstapriv)
+static struct sta_info *rtw_sta_info_get_by_idx(const int idx, struct sta_priv *pstapriv)
 
 {
 

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -138,7 +138,7 @@ void _dynamic_check_timer_handlder(void *FunctionContext)
 
 #ifdef CONFIG_SET_SCAN_DENY_TIMER
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-void _rtw_set_scan_deny_timer_hdl(struct timer_list *t)
+static void _rtw_set_scan_deny_timer_hdl(struct timer_list *t)
 #else
 void _rtw_set_scan_deny_timer_hdl(void *FunctionContext)
 #endif
@@ -360,7 +360,7 @@ void rtw_report_sec_ie(_adapter *adapter, u8 authmode, u8 *sec_ie)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-void _survey_timer_hdl(struct timer_list *t)
+static void _survey_timer_hdl(struct timer_list *t)
 #else
 void _survey_timer_hdl(void *FunctionContext)
 #endif
@@ -379,7 +379,7 @@ void _survey_timer_hdl(void *FunctionContext)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-void _link_timer_hdl(struct timer_list *t)
+static void _link_timer_hdl(struct timer_list *t)
 #else
 void _link_timer_hdl(void *FunctionContext)
 #endif
@@ -437,7 +437,7 @@ void _ft_roam_timer_hdl(void *FunctionContext)
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-void _addba_timer_hdl(struct timer_list *t)
+static void _addba_timer_hdl(struct timer_list *t)
 #else
 void _addba_timer_hdl(void *FunctionContext)
 #endif

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -624,7 +624,7 @@ module_param(rtw_en_gro, int, 0644);
 #endif /* CONFIG_RTW_GRO */
 #endif /* CONFIG_RTW_NAPI */
 
-void rtw_regsty_load_target_tx_power(struct registry_priv *regsty)
+static void rtw_regsty_load_target_tx_power(struct registry_priv *regsty)
 {
 	int path, rs;
 	int *target_tx_pwr;
@@ -1048,7 +1048,7 @@ static struct net_device_stats *rtw_net_get_stats(struct net_device *pnetdev)
 static const u16 rtw_1d_to_queue[8] = { 2, 3, 3, 2, 1, 1, 0, 0 };
 
 /* Given a data frame determine the 802.1p/1d tag to use. */
-unsigned int rtw_classify8021d(struct sk_buff *skb)
+static unsigned int rtw_classify8021d(struct sk_buff *skb)
 {
 	unsigned int dscp;
 
@@ -1178,7 +1178,7 @@ void rtw_ndev_notifier_unregister(void)
 }
 
 
-int rtw_ndev_init(struct net_device *dev)
+static int rtw_ndev_init(struct net_device *dev)
 {
 	_adapter *adapter = rtw_netdev_priv(dev);
 
@@ -1191,7 +1191,7 @@ int rtw_ndev_init(struct net_device *dev)
 	return 0;
 }
 
-void rtw_ndev_uninit(struct net_device *dev)
+static void rtw_ndev_uninit(struct net_device *dev)
 {
 	_adapter *adapter = rtw_netdev_priv(dev);
 
@@ -1262,7 +1262,7 @@ int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 	return 0;
 }
 
-void rtw_hook_if_ops(struct net_device *ndev)
+static void rtw_hook_if_ops(struct net_device *ndev)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29))
 	ndev->netdev_ops = &rtw_netdev_ops;
@@ -1327,7 +1327,7 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 	return pnetdev;
 }
 
-int rtw_os_ndev_alloc(_adapter *adapter)
+static int rtw_os_ndev_alloc(_adapter *adapter)
 {
 	int ret = _FAIL;
 	struct net_device *ndev = NULL;
@@ -1369,7 +1369,7 @@ void rtw_os_ndev_free(_adapter *adapter)
 	}
 }
 
-int rtw_os_ndev_register(_adapter *adapter, const char *name)
+static int rtw_os_ndev_register(_adapter *adapter, const char *name)
 {
 	int ret = _SUCCESS;
 	struct net_device *ndev = adapter->pnetdev;
@@ -1497,7 +1497,7 @@ void rtw_os_ndev_deinit(_adapter *adapter)
 	rtw_os_ndev_free(adapter);
 }
 
-int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
+static int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
 {
 	int i, status = _SUCCESS;
 	_adapter *adapter;
@@ -1550,7 +1550,7 @@ exit:
 	return status;
 }
 
-void rtw_os_ndevs_free(struct dvobj_priv *dvobj)
+static void rtw_os_ndevs_free(struct dvobj_priv *dvobj)
 {
 	int i;
 	_adapter *adapter = NULL;
@@ -2522,7 +2522,7 @@ void rtw_drv_del_vir_ifaces(_adapter *primary_padapter)
 
 #endif /*end of CONFIG_CONCURRENT_MODE*/
 
-int rtw_os_ndevs_register(struct dvobj_priv *dvobj)
+static int rtw_os_ndevs_register(struct dvobj_priv *dvobj)
 {
 	int i, status = _SUCCESS;
 	struct registry_priv *regsty = dvobj_to_regsty(dvobj);
@@ -2865,7 +2865,7 @@ int netdev_open(struct net_device *pnetdev)
 }
 
 #ifdef CONFIG_IPS
-int  ips_netdrv_open(_adapter *padapter)
+static int  ips_netdrv_open(_adapter *padapter)
 {
 	int status = _SUCCESS;
 	/* struct pwrctrl_priv	*pwrpriv = adapter_to_pwrctl(padapter); */
@@ -3773,7 +3773,7 @@ int rtw_suspend_ap_wow(_adapter *padapter)
 #endif /* #ifdef CONFIG_AP_WOWLAN */
 
 
-int rtw_suspend_normal(_adapter *padapter)
+static int rtw_suspend_normal(_adapter *padapter)
 {
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
@@ -4207,7 +4207,7 @@ exit:
 }
 #endif /* #ifdef CONFIG_APWOWLAN */
 
-void rtw_mi_resume_process_normal(_adapter *padapter)
+static void rtw_mi_resume_process_normal(_adapter *padapter)
 {
 	int i;
 	_adapter *iface;
@@ -4236,7 +4236,7 @@ void rtw_mi_resume_process_normal(_adapter *padapter)
 	}
 }
 
-int rtw_resume_process_normal(_adapter *padapter)
+static int rtw_resume_process_normal(_adapter *padapter)
 {
 	struct net_device *pnetdev;
 	struct pwrctrl_priv *pwrpriv;

--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -860,7 +860,7 @@ void rtw_os_read_port(_adapter *padapter, struct recv_buf *precvbuf)
 
 }
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-void _rtw_reordering_ctrl_timeout_handler(struct timer_list *t)
+static void _rtw_reordering_ctrl_timeout_handler(struct timer_list *t)
 #else
 void _rtw_reordering_ctrl_timeout_handler(void *FunctionContext)
 #endif

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -363,7 +363,7 @@ int rtw_android_cmdstr_to_num(char *cmdstr)
 	return cmd_num;
 }
 
-int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(net);
 	struct	mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
@@ -378,7 +378,7 @@ int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
 	return bytes_written;
 }
 
-int rtw_android_get_link_speed(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_link_speed(struct net_device *net, char *command, int total_len)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(net);
 	struct	mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
@@ -392,7 +392,7 @@ int rtw_android_get_link_speed(struct net_device *net, char *command, int total_
 	return bytes_written;
 }
 
-int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	int bytes_written = 0;
@@ -401,7 +401,7 @@ int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len
 	return bytes_written;
 }
 
-int rtw_android_set_country(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_country(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *country_code = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_COUNTRY]) + 1;
@@ -412,7 +412,7 @@ int rtw_android_set_country(struct net_device *net, char *command, int total_len
 	return (ret == _SUCCESS) ? 0 : -1;
 }
 
-int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int total_len)
 {
 	int bytes_written = 0;
 
@@ -423,7 +423,7 @@ int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int tota
 	return bytes_written;
 }
 
-int rtw_android_set_block_scan(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_block_scan(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *block_value = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_BLOCK_SCAN]) + 1;
@@ -435,7 +435,7 @@ int rtw_android_set_block_scan(struct net_device *net, char *command, int total_
 	return 0;
 }
 
-int rtw_android_set_block(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_block(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *block_value = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_BLOCK]) + 1;
@@ -447,7 +447,7 @@ int rtw_android_set_block(struct net_device *net, char *command, int total_len)
 	return 0;
 }
 
-int rtw_android_setband(struct net_device *net, char *command, int total_len)
+static int rtw_android_setband(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *arg = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_SETBAND]) + 1;
@@ -460,7 +460,7 @@ int rtw_android_setband(struct net_device *net, char *command, int total_len)
 	return (ret == _SUCCESS) ? 0 : -1;
 }
 
-int rtw_android_getband(struct net_device *net, char *command, int total_len)
+static int rtw_android_getband(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	int bytes_written = 0;
@@ -471,7 +471,7 @@ int rtw_android_getband(struct net_device *net, char *command, int total_len)
 }
 
 #ifdef CONFIG_WFD
-int rtw_android_set_miracast_mode(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_miracast_mode(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	struct wifi_display_info *wfd_info = &adapter->wfd_info;
@@ -507,7 +507,7 @@ exit:
 }
 #endif /* CONFIG_WFD */
 
-int get_int_from_command(char *pcmd)
+static int get_int_from_command(char *pcmd)
 {
 	int i = 0;
 

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -144,7 +144,7 @@ int dbg_rtw_cfg80211_vendor_cmd_reply(struct sk_buff *skb
 	dbg_rtw_cfg80211_vendor_cmd_reply(skb, MSTAT_FUNC_CFG_VENDOR | MSTAT_TYPE_SKB, __FUNCTION__, __LINE__)
 #else
 
-struct sk_buff *rtw_cfg80211_vendor_event_alloc(
+static struct sk_buff *rtw_cfg80211_vendor_event_alloc(
 	struct wiphy *wiphy, struct wireless_dev *wdev, int len, int event_id, gfp_t gfp)
 {
 	struct sk_buff *skb;
@@ -234,7 +234,7 @@ static int rtw_cfgvendor_send_cmd_reply(struct wiphy *wiphy,
 #define MAX_FEATURE_SET_CONCURRRENT_GROUPS  3
 
 #include <hal_data.h>
-int rtw_dev_get_feature_set(struct net_device *dev)
+static int rtw_dev_get_feature_set(struct net_device *dev)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	HAL_DATA_TYPE *HalData = GET_HAL_DATA(adapter);
@@ -256,7 +256,7 @@ int rtw_dev_get_feature_set(struct net_device *dev)
 	return feature_set;
 }
 
-int *rtw_dev_get_feature_set_matrix(struct net_device *dev, int *num)
+static int *rtw_dev_get_feature_set_matrix(struct net_device *dev, int *num)
 {
 	int feature_set_full, mem_needed;
 	int *ret;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -851,7 +851,7 @@ static int proc_get_macaddr_acl(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1676,7 +1676,7 @@ static ssize_t proc_set_tx_gain_offset(struct file *file, const char __user *buf
 #endif /* CONFIG_RF_POWER_TRIM */
 
 #ifdef CONFIG_BT_COEXIST
-ssize_t proc_set_btinfo_evt(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btinfo_evt(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1803,7 +1803,7 @@ static int btreg_parse_str(char const *input, u8 *type, u16 *addr, u16 *val)
 	return 0;
 }
 
-int proc_get_btreg_read(struct seq_file *m, void *v)
+static int proc_get_btreg_read(struct seq_file *m, void *v)
 {
 	struct net_device *dev;
 	PADAPTER padapter;
@@ -1826,7 +1826,7 @@ int proc_get_btreg_read(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_btreg_read(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btreg_read(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	PADAPTER padapter;
@@ -1877,7 +1877,7 @@ exit:
 	return count;
 }
 
-int proc_get_btreg_write(struct seq_file *m, void *v)
+static int proc_get_btreg_write(struct seq_file *m, void *v)
 {
 	struct net_device *dev;
 	PADAPTER padapter;
@@ -1904,7 +1904,7 @@ int proc_get_btreg_write(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_btreg_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btreg_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	PADAPTER padapter;
@@ -1972,7 +1972,7 @@ int proc_get_mbid_cam_cache(struct seq_file *m, void *v)
 }
 #endif /* CONFIG_MBSSID_CAM */
 
-int proc_get_mac_addr(struct seq_file *m, void *v)
+static int proc_get_mac_addr(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2480,7 +2480,7 @@ ssize_t proc_set_odm_dbg_level(struct file *file, const char __user *buffer, siz
 	return count;
 }
 
-int proc_get_odm_ability(struct seq_file *m, void *v)
+static int proc_get_odm_ability(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2490,7 +2490,7 @@ int proc_get_odm_ability(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_odm_ability(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_odm_ability(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2519,7 +2519,7 @@ ssize_t proc_set_odm_ability(struct file *file, const char __user *buffer, size_
 	return count;
 }
 
-int proc_get_odm_force_igi_lb(struct seq_file *m, void *v)
+static int proc_get_odm_force_igi_lb(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2529,7 +2529,7 @@ int proc_get_odm_force_igi_lb(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_odm_force_igi_lb(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_odm_force_igi_lb(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2602,7 +2602,7 @@ ssize_t proc_set_odm_adaptivity(struct file *file, const char __user *buffer, si
 static char *phydm_msg = NULL;
 #define PHYDM_MSG_LEN	80*24
 
-int proc_get_phydm_cmd(struct seq_file *m, void *v)
+static int proc_get_phydm_cmd(struct seq_file *m, void *v)
 {
 	struct net_device *netdev;
 	PADAPTER padapter;
@@ -2631,7 +2631,7 @@ int proc_get_phydm_cmd(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_phydm_cmd(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_phydm_cmd(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *netdev;
 	PADAPTER padapter;
@@ -2765,7 +2765,7 @@ static const struct file_operations rtw_odm_proc_sseq_fops = {
 };
 #endif
 
-struct proc_dir_entry *rtw_odm_proc_init(struct net_device *dev)
+static struct proc_dir_entry *rtw_odm_proc_init(struct net_device *dev)
 {
 	struct proc_dir_entry *dir_odm = NULL;
 	struct proc_dir_entry *entry = NULL;
@@ -2808,7 +2808,7 @@ exit:
 	return dir_odm;
 }
 
-void rtw_odm_proc_deinit(_adapter	*adapter)
+static void rtw_odm_proc_deinit(_adapter	*adapter)
 {
 	struct proc_dir_entry *dir_odm = NULL;
 	int i;

--- a/os_dep/linux/sdio_intf.c
+++ b/os_dep/linux/sdio_intf.c
@@ -545,7 +545,7 @@ static void sd_intf_stop(PADAPTER padapter)
 PADAPTER g_test_adapter = NULL;
 #endif /* RTW_SUPPORT_PLATFORM_SHUTDOWN */
 
-_adapter *rtw_sdio_primary_adapter_init(struct dvobj_priv *dvobj)
+static _adapter *rtw_sdio_primary_adapter_init(struct dvobj_priv *dvobj)
 {
 	int status = _FAIL;
 	PADAPTER padapter = NULL;

--- a/os_dep/linux/wifi_regd.c
+++ b/os_dep/linux/wifi_regd.c
@@ -453,7 +453,7 @@ static const struct ieee80211_regdomain *_rtw_regdomain_select(struct
 #endif
 }
 
-void _rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)
+static void _rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)
 {
 	struct rtw_regulatory *reg = NULL;
 
@@ -465,7 +465,7 @@ void _rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0))
 int rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)
 #else
-void rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)
+static void rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)
 #endif
 {
 	_rtw_reg_notifier(wiphy, request);

--- a/os_dep/linux/xmit_linux.c
+++ b/os_dep/linux/xmit_linux.c
@@ -355,7 +355,7 @@ void rtw_os_wake_queue_at_free_stainfo(_adapter *padapter, int *qcnt_freed)
 }
 
 #ifdef CONFIG_TX_MCAST2UNI
-int rtw_mlcst2unicst(_adapter *padapter, struct sk_buff *skb)
+static int rtw_mlcst2unicst(_adapter *padapter, struct sk_buff *skb)
 {
 	struct	sta_priv *pstapriv = &padapter->stapriv;
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;


### PR DESCRIPTION
## What

Eliminates 328 of 330 -Wmissing-prototypes warnings emitted when the
driver is built into a modern kernel (verified on 6.18, odroidm1):

- file-private functions get `static`
- genuinely cross-file functions get a forward declaration in a
  type-aware home header (rtw_br_ext.h, mlme_osdep.h, osdep_intf.h,
  rtw_btcoex.h), or a self-include where a declaration already existed

No functional change — only linkage and declarations.

## Remaining 2 warnings (left untouched on purpose)

- update_hidden_ssid — a config-guarded (CONFIG_P2P_WOWLAN) static
  namesake exists in hal/hal_com.c; a shared prototype would clash
- rtw_change_ifname — its natural home header (osdep_service.h) does
  not know the _adapter type

## Verified

Builds cleanly into kernel 6.18 (odroidm1): 0 errors, 0 modpost issues,
warnings 330 -> 2. Applies cleanly onto current HEAD.

## Header guards (-Wheader-guard)

Six headers had include guards whose `#ifndef` and `#define` named different (typo'd) macros, so the guard never took effect and clang emits `-Wheader-guard`:

| file | fix |
|---|---|
| `hal/phydm/phydm_features.h` | `#define __PHYDM_FEATURES` → `__PHYDM_FEATURES_H__` |
| `hal/phydm/phydm_kfree.h` | `#define __PHYDKFREE_H__` → `__PHYDMKFREE_H__` |
| `include/custom_gpio.h` | `#define __CUSTOM_GPIO_H___` → `__CUSTOM_GPIO_H__` |
| `include/rtl8814a_sreset.h` | `#ifndef _RTL88814A_SRESET_H_` → `_RTL8814A_SRESET_H_` |
| `include/rtl8812a_sreset.h` | `#ifndef _RTL88812A_SRESET_H_` → `_RTL8812A_SRESET_H_` |
| `include/rtl8192e_sreset.h` | `_RTL88812A_`/`_RTL8812A_` → `_RTL8192E_SRESET_H_` (own guard) |

`rtl8192e_sreset.h` carried `rtl8812a`'s guard name verbatim, which would collide once consistent, so it gets its own `_RTL8192E_SRESET_H_`.

---
*Commits are split by subsystem (core / os_dep / hal / hal/rtl8723d) for independent review. Verified under `x86_64 defconfig` (`CONFIG_WERROR`) on Linux 6.12.93: builds to `.ko` cleanly, **2** `-Wmissing-prototypes` remaining (the documented hard cases), 0 `-Wunused-function`.*

