### PR TITLE
Import two long-carried armbian/build patches, with authorship

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4227,6 +4227,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
 
 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
 
+	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
+	if (ret == 0) {
+		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
+
+		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
+	}
+
 	if (settings->ssid && settings->ssid_len) {
 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
@@ -4266,6 +4275,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+
+	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
+	if (ret == 0) {
+		if (info->proberesp_ies && info->proberesp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
+
+		if (info->assocresp_ies && info->assocresp_ies_len > 0)
+			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
+	}
 
 	return ret;
 }

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -25,6 +25,10 @@
 
 #define RT_TAG	'1178'
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0))
+MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+#endif
+
 #ifdef DBG_MEMORY_LEAK
 atomic_t _malloc_cnt = ATOMIC_INIT(0);
 atomic_t _malloc_size = ATOMIC_INIT(0);


### PR DESCRIPTION
## What

Brings two patches that armbian/build has carried out-of-tree for years
into the repo itself, with original authorship preserved (git am):

- Fix p2p-go advertising (@Azq2) — explicitly sets the proberesp /
  assocresp IEs after start_ap and change_beacon, so WPS works when those
  IEs differ from the beacon.
- Fix VFS import (@efectn) — adds MODULE_IMPORT_NS for kernels 5.4–6.13,
  without which the module does not build on those kernels.

## Why

Both are general, non-armbian-specific fixes (one functional, one
build-compat), yet they live only in armbian/build's patch/misc/. The
history explains it:

- Both landed in armbian/build in early 2023 (PRs armbian/build#4717 and
  armbian/build#4775), when upstream lwfinger/rtl8723ds was still active
  and armbian only snapshotted it and applied build-side patches.
- lwfinger/rtl8723ds has had no commits since 2023-11; this fork became
  the de-facto continuation, taking kernel-compat commits directly from
  late 2024 on.
- The two 2023 patches were never migrated when the workflow shifted —
  they just kept working at build time.

Landing them here means everyone building the driver gets the fixes, not
only via armbian/build, and there is a single source of truth.

## To the authors

@Azq2 @efectn — this only relocates your work into the repo, authorship
intact, nothing rewritten. Thanks for the original fixes.