### PR TITLE
phydm: fix broken include guards in phydm_features.h and phydm_kfree.h

### DIFF
--- a/hal/phydm/phydm_features.h
+++ b/hal/phydm/phydm_features.h
@@ -19,7 +19,7 @@
  ******************************************************************************/
 
 #ifndef	__PHYDM_FEATURES_H__
-#define __PHYDM_FEATURES
+#define __PHYDM_FEATURES_H__
 
 
 #if (DM_ODM_SUPPORT_TYPE == ODM_WIN)

--- a/hal/phydm/phydm_kfree.h
+++ b/hal/phydm/phydm_kfree.h
@@ -20,7 +20,7 @@
  ******************************************************************************/
 
 #ifndef	__PHYDMKFREE_H__
-#define    __PHYDKFREE_H__
+#define    __PHYDMKFREE_H__
 
 #define KFREE_VERSION	"1.0"
 


### PR DESCRIPTION
Two phydm headers have include guards where the `#define` does not match the `#ifndef` macro, so the guard never engages (a copy-paste truncation):

| file | `#ifndef` | `#define` (was) | fixed to |
|---|---|---|---|
| `hal/phydm/phydm_features.h` | `__PHYDM_FEATURES_H__` | `__PHYDM_FEATURES` | `__PHYDM_FEATURES_H__` |
| `hal/phydm/phydm_kfree.h` | `__PHYDMKFREE_H__` | `__PHYDKFREE_H__` | `__PHYDMKFREE_H__` |

GCC stays silent, but a clang kernel build emits 203 `-Wheader-guard` warnings from these two headers (observed building odroidn2 / meson64 edge 7.1.3 with `KERNEL_COMPILER=clang`). Aligning each `#define` with its `#ifndef` silences them and restores the intended double-include protection. No behavioral change under GCC.