### PR TITLE
add compat for 7.2

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4111,7 +4111,12 @@ bool rtw_wowlan_parser_pattern_cmd(u8 *input, char *pattern,
 		} else {
 			u8 hex;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			strscpy(member, input, len);
+#else
 			strncpy(member, input, len);
+#endif
+
 			if (!rtw_check_pattern_valid(member, sizeof(member))) {
 				RTW_INFO("%s:[ERROR] pattern is invalid!!\n",
 					 __func__);

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -8469,7 +8469,11 @@ ParseQualifiedString(
 	while ((c = In[(*Start)++]) != RightQualifier)
 		; /* find ']' */
 	j = (*Start) - 2;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy((char *)Out, (const char *)(In + i), j - i + 1);
+#else
 	strncpy((char *)Out, (const char *)(In + i), j - i + 1);
+#endif
 
 	return _TRUE;
 }

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -5065,9 +5065,15 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 				if (strlen(szLine) < 10 || szLine[0] != '[')
 					continue;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+				strscpy(band, szLine + 1, 2);
+				strscpy(path, szLine + 5, 1);
+				strscpy(sign, szLine + 8, 1);
+#else
 				strncpy(band, szLine + 1, 2);
 				strncpy(path, szLine + 5, 1);
 				strncpy(sign, szLine + 8, 1);
+#endif
 
 				i = 10; /* szLine+10 */
 				if (!ParseQualifiedString(szLine, &i, rate, '[', ']')) {

--- a/hal/hal_hci/hal_sdio.c
+++ b/hal/hal_hci/hal_sdio.c
@@ -36,13 +36,21 @@ static void dump_sdio_f0(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+		strscpy(str_out, str_val, len);
+#else
 		strncpy(str_out, str_val, len);
+#endif
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_sd_f0_read8(padapter, index + i));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			strscpy(p, str_val, len);
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);
@@ -63,13 +71,21 @@ static void dump_sdio_local(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+		strscpy(str_out, str_val, len);
+#else
 		strncpy(str_out, str_val, len);
+#endif
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_read8(padapter, (0x1025 << 16) | (index + i)));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			strscpy(p, str_val, len);
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);
@@ -90,13 +106,21 @@ static void dump_mac_page0(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+		strscpy(str_out, str_val, len);
+#else
 		strncpy(str_out, str_val, len);
+#endif
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_read8(padapter, index + i));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+			strscpy(p, str_val, len);
+#else
 			strncpy(p, str_val, len);
+#endif
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -2662,7 +2662,11 @@ phydm_fw_trace_handler(
 		return;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy((char *)&(pDM_Odm->fw_debug_trace[pDM_Odm->c2h_cmd_start]), (char *)&CmdBuf[1], (CmdLen-1));
+#else
 	strncpy((char *)&(pDM_Odm->fw_debug_trace[pDM_Odm->c2h_cmd_start]), (char *)&CmdBuf[1], (CmdLen-1));
+#endif
 	pDM_Odm->c2h_cmd_start += (CmdLen - 1);
 	pDM_Odm->fw_buff_is_enpty = FALSE;	
 	

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1481,7 +1481,12 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy,
 		goto addkey_end;
 	}
 
-	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+		strscpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+	#else
+		strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+	#endif
 
 
 	if (!mac_addr || is_broadcast_ether_addr(mac_addr)) {
@@ -3889,8 +3894,12 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	}
 
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
-	strncpy(mon_ndev->name, name, IFNAMSIZ);
-	mon_ndev->name[IFNAMSIZ - 1] = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy(mon_ndev->name, name, IFNAMSIZ);
+#else
+		strncpy(mon_ndev->name, name, IFNAMSIZ);
+		mon_ndev->name[IFNAMSIZ - 1] = 0;
+#endif
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4, 11, 8))
 	mon_ndev->priv_destructor = rtw_ndev_destructor;
 #else
@@ -5175,7 +5184,11 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0))
 	enum nl80211_channel_type channel_type,
 #endif
-	unsigned int duration, u64 *cookie)
+	unsigned int duration, u64 *cookie
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	, const u8 *rx_addr
+#endif
+)
 {
 	s32 err = 0;
 	u8 remain_ch = (u8) ieee80211_frequency_to_channel(channel->center_freq);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -3536,7 +3536,11 @@ static int rtw_wx_set_enc_ext(struct net_device *dev,
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#else
 	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+#endif
 
 	if (pext->ext_flags & IW_ENCODE_EXT_SET_TX_KEY)
 		param->u.crypt.set_tx = 1;
@@ -6377,10 +6381,15 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 		else
 #endif
 			reg_ifname = padapter->registrypriv.if2name;
-
-		strncpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
-		rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
+	
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
+#else
+	strncpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
+	 rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
+#endif
 	}
+
 
 	/* RTW_INFO("%s wrqu->data.length:%d\n", __FUNCTION__, wrqu->data.length); */
 	if (wrqu->data.length > IFNAMSIZ)
@@ -6403,8 +6412,12 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 		/* rtw_ips_mode_req(&padapter->pwrctrlpriv, rereg_priv->old_ips_mode); */
 	}
 
-	strncpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
-	rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
+#else
+		strncpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
+		rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
+#endif
 
 	if (_rtw_memcmp(new_ifname, "disable%d", 9) == _TRUE) {
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1184,8 +1184,12 @@ int rtw_ndev_init(struct net_device *dev)
 
 	RTW_PRINT(FUNC_ADPT_FMT" if%d mac_addr="MAC_FMT"\n"
 		, FUNC_ADPT_ARG(adapter), (adapter->iface_id + 1), MAC_ARG(dev->dev_addr));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	strscpy(adapter->old_ifname, dev->name, IFNAMSIZ);
+#else
 	strncpy(adapter->old_ifname, dev->name, IFNAMSIZ);
 	adapter->old_ifname[IFNAMSIZ - 1] = '\0';
+#endif
 	rtw_adapter_proc_init(dev);
 
 	return 0;


### PR DESCRIPTION
- Replace all strncpy() with strscpy() (KERNEL_VERSION >= 7.2.0) strncpy() was removed from kernel in 7.2
- Update cfg80211_rtw_remain_on_channel() signature Add const u8 *rx_addr parameter for kernel >= 7.2.0