### PR TITLE
Keep strncpy() byte-count semantics on Linux 7.2+

### DIFF
--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4111,11 +4111,7 @@ bool rtw_wowlan_parser_pattern_cmd(u8 *input, char *pattern,
 		} else {
 			u8 hex;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-			strscpy(member, input, len);
-#else
-			strncpy(member, input, len);
-#endif
+			memcpy(member, input, len);
 
 			if (!rtw_check_pattern_valid(member, sizeof(member))) {
 				RTW_INFO("%s:[ERROR] pattern is invalid!!\n",

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -8469,11 +8469,7 @@ ParseQualifiedString(
 	while ((c = In[(*Start)++]) != RightQualifier)
 		; /* find ']' */
 	j = (*Start) - 2;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-	strscpy((char *)Out, (const char *)(In + i), j - i + 1);
-#else
-	strncpy((char *)Out, (const char *)(In + i), j - i + 1);
-#endif
+	memcpy((char *)Out, (const char *)(In + i), j - i + 1);
 
 	return _TRUE;
 }

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -5065,15 +5065,9 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 				if (strlen(szLine) < 10 || szLine[0] != '[')
 					continue;
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-				strscpy(band, szLine + 1, 2);
-				strscpy(path, szLine + 5, 1);
-				strscpy(sign, szLine + 8, 1);
-#else
-				strncpy(band, szLine + 1, 2);
-				strncpy(path, szLine + 5, 1);
-				strncpy(sign, szLine + 8, 1);
-#endif
+				memcpy(band, szLine + 1, 2);
+				memcpy(path, szLine + 5, 1);
+				memcpy(sign, szLine + 8, 1);
 
 				i = 10; /* szLine+10 */
 				if (!ParseQualifiedString(szLine, &i, rate, '[', ']')) {

--- a/hal/hal_hci/hal_sdio.c
+++ b/hal/hal_hci/hal_sdio.c
@@ -36,21 +36,13 @@ static void dump_sdio_f0(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-		strscpy(str_out, str_val, len);
-#else
-		strncpy(str_out, str_val, len);
-#endif
+		memcpy(str_out, str_val, len);
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_sd_f0_read8(padapter, index + i));
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-			strscpy(p, str_val, len);
-#else
-			strncpy(p, str_val, len);
-#endif
+			memcpy(p, str_val, len);
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);
@@ -71,21 +63,13 @@ static void dump_sdio_local(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-		strscpy(str_out, str_val, len);
-#else
-		strncpy(str_out, str_val, len);
-#endif
+		memcpy(str_out, str_val, len);
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_read8(padapter, (0x1025 << 16) | (index + i)));
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-			strscpy(p, str_val, len);
-#else
-			strncpy(p, str_val, len);
-#endif
+			memcpy(p, str_val, len);
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);
@@ -106,21 +90,13 @@ static void dump_mac_page0(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-		strscpy(str_out, str_val, len);
-#else
-		strncpy(str_out, str_val, len);
-#endif
+		memcpy(str_out, str_val, len);
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_read8(padapter, index + i));
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-			strscpy(p, str_val, len);
-#else
-			strncpy(p, str_val, len);
-#endif
+			memcpy(p, str_val, len);
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -2662,11 +2662,7 @@ phydm_fw_trace_handler(
 		return;
 	}
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
-	strscpy((char *)&(pDM_Odm->fw_debug_trace[pDM_Odm->c2h_cmd_start]), (char *)&CmdBuf[1], (CmdLen-1));
-#else
-	strncpy((char *)&(pDM_Odm->fw_debug_trace[pDM_Odm->c2h_cmd_start]), (char *)&CmdBuf[1], (CmdLen-1));
-#endif
+	memcpy((char *)&(pDM_Odm->fw_debug_trace[pDM_Odm->c2h_cmd_start]), (char *)&CmdBuf[1], (CmdLen-1));
 	pDM_Odm->c2h_cmd_start += (CmdLen - 1);
 	pDM_Odm->fw_buff_is_enpty = FALSE;	
 	


### PR DESCRIPTION
The 7.2 compat commit (2e63716f) replaced `strncpy(dst, src, n)` with `strscpy(dst, src, n)` at sites where `n` is the number of bytes to copy, not the destination size; `strscpy()` reserves one byte for the terminator, so each of these copies drops its last character: the wowlan pattern parser, `ParseQualifiedString()` ("50" → "5", corrupting TX-power-limit and other parameter-file parsers), band/path/sign in `PHY_ConfigRFWithTxPwrTrackParaFile()` ("2"/""/"" — selectors never match), the SDIO register dumps, the phydm FW debug trace. Use `memcpy()`: buffers are zero-initialised or terminated by the surrounding code, so this is exactly what `strncpy()` did, on every kernel, and the version split goes away. 12 sites in 5 files; builds clean on 7.1.7 headers and a 7.2 tree.