### PR TITLE
proc: read only what was written in the sa_query / tx_deauth / tx_auth handlers

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -4006,16 +4006,15 @@ ssize_t proc_set_tx_sa_query(struct file *file, const char __user *buffer, size_
 		return -EFAULT;
 	}
 
-	if (buffer && !copy_from_user(tmp, buffer, sizeof(tmp))) {
+	if (!buffer || copy_from_user(tmp, buffer, count))
+		return -EFAULT;
+	tmp[count] = '\0';
 
-		int num = sscanf(tmp, "%x", &key_type);
-
-		if (num !=  1) {
-			RTW_INFO("invalid read_reg parameter!\n");
-			return count;
-		}
-		RTW_INFO("0: set sa query request , key_type=%d\n", key_type);
+	if (sscanf(tmp, "%x", &key_type) != 1) {
+		RTW_INFO("invalid read_reg parameter!\n");
+		return count;
 	}
+	RTW_INFO("0: set sa query request , key_type=%d\n", key_type);
 
 	if ((check_fwstate(pmlmepriv, WIFI_STATION_STATE) == _TRUE)
 	    && (check_fwstate(pmlmepriv, _FW_LINKED) == _TRUE) && padapter->securitypriv.binstallBIPkey == _TRUE) {
@@ -4087,16 +4086,15 @@ ssize_t proc_set_tx_deauth(struct file *file, const char __user *buffer, size_t 
 		return -EFAULT;
 	}
 
-	if (buffer && !copy_from_user(tmp, buffer, sizeof(tmp))) {
+	if (!buffer || copy_from_user(tmp, buffer, count))
+		return -EFAULT;
+	tmp[count] = '\0';
 
-		int num = sscanf(tmp, "%x", &key_type);
-
-		if (num !=  1) {
-			RTW_INFO("invalid read_reg parameter!\n");
-			return count;
-		}
-		RTW_INFO("key_type=%d\n", key_type);
+	if (sscanf(tmp, "%x", &key_type) != 1) {
+		RTW_INFO("invalid read_reg parameter!\n");
+		return count;
 	}
+	RTW_INFO("key_type=%d\n", key_type);
 	if (key_type < 0 || key_type > 4)
 		return count;
 
@@ -4192,16 +4190,15 @@ ssize_t proc_set_tx_auth(struct file *file, const char __user *buffer, size_t co
 		return -EFAULT;
 	}
 
-	if (buffer && !copy_from_user(tmp, buffer, sizeof(tmp))) {
+	if (!buffer || copy_from_user(tmp, buffer, count))
+		return -EFAULT;
+	tmp[count] = '\0';
 
-		int num = sscanf(tmp, "%x", &tx_auth);
-
-		if (num !=  1) {
-			RTW_INFO("invalid read_reg parameter!\n");
-			return count;
-		}
-		RTW_INFO("1: setnd auth, 2: send assoc request. tx_auth=%d\n", tx_auth);
+	if (sscanf(tmp, "%x", &tx_auth) != 1) {
+		RTW_INFO("invalid read_reg parameter!\n");
+		return count;
 	}
+	RTW_INFO("1: setnd auth, 2: send assoc request. tx_auth=%d\n", tx_auth);
 
 	if ((check_fwstate(pmlmepriv, WIFI_STATION_STATE) == _TRUE)
 	    && (check_fwstate(pmlmepriv, _FW_LINKED) == _TRUE)) {


### PR DESCRIPTION
The three handlers copy sizeof(tmp) (16) bytes from user space even
though they have just limited count to 2, so a short write near the end
of a page can fault on bytes the caller never passed. On a failed copy
they carry on with key_type / tx_auth uninitialised and, for tx_deauth,
send a deauth with that value as the reason.

Copy count bytes, terminate, and return -EFAULT when the copy fails.
Found by clang -Wsometimes-uninitialized (rtl88x2cs; the same code is in
rtl8723ds and rtl8852bs). Does not overlap the open PRs.
