### PR TITLE
Fix two clang findings: dead recv-frame helpers, inverted HT/VHT test in phydm_debug

### DIFF
--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -690,7 +690,7 @@ phydm_BB_Debug_Info(
 		else if (*pDM_Odm->pBandWidth == ODM_BW40M)
 			factor = "128/108";
 		else if (*pDM_Odm->pBandWidth == ODM_BW20M) {
-			if (RX_HT != 2 || RX_HT != 1)
+			if (RX_HT == 2 || RX_HT == 1)
 				factor = "64/52";	/*HT or VHT*/
 			else
 				factor = "64/48";	/*legacy*/

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -740,58 +740,6 @@ __inline static u8 *recvframe_pull_tail(union recv_frame *precvframe, sint sz)
 }
 
 
-
-__inline static _buffer *get_rxbuf_desc(union recv_frame *precvframe)
-{
-	_buffer *buf_desc;
-
-	if (precvframe == NULL)
-		return NULL;
-	return buf_desc;
-}
-
-
-__inline static union recv_frame *rxmem_to_recvframe(u8 *rxmem)
-{
-	/* due to the design of 2048 bytes alignment of recv_frame, we can reference the union recv_frame */
-	/* from any given member of recv_frame. */
-	/* rxmem indicates the any member/address in recv_frame */
-
-	return (union recv_frame *)(((SIZE_PTR)rxmem >> RXFRAME_ALIGN) << RXFRAME_ALIGN);
-
-}
-
-__inline static union recv_frame *pkt_to_recvframe(_pkt *pkt)
-{
-
-	u8 *buf_star;
-	union recv_frame *precv_frame;
-	precv_frame = rxmem_to_recvframe((unsigned char *)buf_star);
-
-	return precv_frame;
-}
-
-__inline static u8 *pkt_to_recvmem(_pkt *pkt)
-{
-	/* return the rx_head */
-
-	union recv_frame *precv_frame = pkt_to_recvframe(pkt);
-
-	return	precv_frame->u.hdr.rx_head;
-
-}
-
-__inline static u8 *pkt_to_recvdata(_pkt *pkt)
-{
-	/* return the rx_data */
-
-	union recv_frame *precv_frame = pkt_to_recvframe(pkt);
-
-	return	precv_frame->u.hdr.rx_data;
-
-}
-
-
 __inline static sint get_recvframe_len(union recv_frame *precvframe)
 {
 	return precvframe->u.hdr.len;


### PR DESCRIPTION
A clang build (LLVM=1, arm64, 7.1 headers) turned up two defects:

- include/rtw_recv.h: get_rxbuf_desc(), rxmem_to_recvframe(),
  pkt_to_recvframe(), pkt_to_recvmem() and pkt_to_recvdata() have no
  callers, and the first and third return a local that is never assigned
  (-Wuninitialized in every TU that includes the header). Removed.
- phydm_debug.c:693: RX_HT != 2 || RX_HT != 1 is always true, so the
  legacy "64/48" factor was unreachable and every 20 MHz frame was
  labelled HT/VHT in the debug output. Test == 2 || == 1 as intended.

gcc + clang builds: no errors; clang -Wuninitialized 226 -> 0,
-Wtautological-overlap-compare 1 -> 0, every other class unchanged.
Does not overlap #6-#16.
