### PR TITLE
Use C99 flexible array members for the trailing variable-length arrays (-Warray-bounds 30 -> 0)

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -242,7 +242,7 @@ typedef struct ieee_param {
 		struct {
 			u32 len;
 			u8 reserved[32];
-			u8 data[0];
+			u8 data[];
 		} wpa_ie;
 		struct {
 			int command;
@@ -255,7 +255,7 @@ typedef struct ieee_param {
 			u8 idx;
 			u8 seq[8]; /* sequence counter (set: RX, get: TX) */
 			u16 key_len;
-			u8 key[0];
+			u8 key[];
 		} crypt;
 #ifdef CONFIG_AP_MODE
 		struct {
@@ -267,7 +267,7 @@ typedef struct ieee_param {
 		} add_sta;
 		struct {
 			u8	reserved[2];/* for set max_num_sta */
-			u8	buf[0];
+			u8	buf[];
 		} bcn_ie;
 #endif
 
@@ -278,7 +278,7 @@ typedef struct ieee_param {
 typedef struct ieee_param_ex {
 	u32 cmd;
 	u8 sta_addr[ETH_ALEN];
-	u8 data[0];
+	u8 data[];
 } ieee_param_ex;
 
 struct sta_data {
@@ -1085,7 +1085,7 @@ struct ieee80211_info_element_hdr {
 struct ieee80211_info_element {
 	u8 id;
 	u8 len;
-	u8 data[0];
+	u8 data[];
 } __attribute__((packed));
 
 /*

--- a/include/wlan_bssdef.h
+++ b/include/wlan_bssdef.h
@@ -96,7 +96,7 @@ typedef struct _NDIS_802_11_FIXED_IEs {
 typedef struct _NDIS_802_11_VARIABLE_IEs {
 	UCHAR  ElementID;
 	UCHAR  Length;
-	UCHAR  data[1];
+	UCHAR  data[];
 } NDIS_802_11_VARIABLE_IEs, *PNDIS_802_11_VARIABLE_IEs;
 
 


### PR DESCRIPTION
ieee80211.h (wpa_ie.data, crypt.key, bcn_ie.buf, ieee_param_ex.data,
info_element.data) and wlan_bssdef.h (NDIS_802_11_VARIABLE_IEs.data)
declared their trailing payloads as [0] / [1]. Since 6.5 the kernel
builds with -fstrict-flex-arrays=3, so only [] is treated as a flexible
array and every index into these members is reported as out of bounds
(clang -Warray-bounds, 30 -> 0). None of the affected types is used with
sizeof(), so no size changes.

gcc + clang builds: no errors, every other class unchanged. Does not
overlap the open PRs.
